### PR TITLE
feat(zoom): CAD-style zoom — cursor-anchored wheel, tier header, settings

### DIFF
--- a/docs/superpowers/plans/2026-05-01-zoom-improvements.md
+++ b/docs/superpowers/plans/2026-05-01-zoom-improvements.md
@@ -1,0 +1,1021 @@
+# Zoom Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make timeline zooming feel like CAD — plain mouse wheel zooms toward the cursor, the header gracefully transitions from years down to quarter-hours, the existing low-zoom glitch is gone, horizontal scroll works, with all behavior configurable.
+
+**Architecture:** A new `timelineTiers.ts` data table drives a rewritten `drawTimelineHeader`. A new `useGanttZoom` hook owns the wheel handler and cursor-anchored zoom math; `useZoomShortcuts` adds `+`/`-`/`0`/`Ctrl+0`. Settings live in `UIState` (the existing pattern — `uiTheme` already lives there).
+
+**Tech Stack:** TypeScript, React 19, Zustand (with Immer), HTML5 Canvas 2D, Vite. No test framework installed — verification is via `tsc` (run as part of `npm run build`) plus manual checks in the running dev server.
+
+---
+
+## File Plan
+
+**New files:**
+- `src/engine/renderer/timelineTiers.ts` — pure tier data + `pickTiers(zoom, enableQuarterHour)` selector
+- `src/hooks/useGanttZoom.ts` — wheel handler, cursor-anchored `zoomAt`, optional smooth animation
+- `src/hooks/useZoomShortcuts.ts` — keyboard shortcuts wired to `useGanttZoom`
+
+**Modified files:**
+- `src/state/slices/types.ts` — extend `UIState` with new settings
+- `src/state/appStore.ts` — defaults, dynamic clamp on `setZoom`, clamp on `enableQuarterHourZoom` toggle
+- `src/utils/dateUtils.ts` — week-start-aware `getWeekNumber`, helper for week start
+- `src/engine/renderer/GanttRenderer.ts` — rewrite `drawTimelineHeader` using tiers, pass `weekStartDay` through options
+- `src/components/canvas/GanttCanvas.tsx` — replace inline wheel effect with hooks, fix horizontal scroll bug, pass `weekStartDay` to renderer
+- `src/components/dialogs/SettingsDialog.tsx` — new "Tijdlijn / Zoomen" section
+- `src/i18n/locales/{nl,en}/common.json` — translations for the new settings (other languages fall back to English via i18next default)
+
+---
+
+## Task 1: Add settings fields + dynamic zoom clamp to state
+
+**Files:**
+- Modify: `src/state/slices/types.ts`
+- Modify: `src/state/appStore.ts`
+
+- [ ] **Step 1: Extend `UIState` interface**
+
+In `src/state/slices/types.ts`, add the two new type aliases above `UIState`, then add four fields to `UIState` (after `uiTheme`):
+
+```ts
+export type MouseWheelMode = 'zoom' | 'scroll';
+export type WeekStartDay = 'monday' | 'sunday';
+
+export interface UIState {
+  // ... keep all existing fields ...
+  uiTheme: UITheme;
+  mouseWheelMode: MouseWheelMode;
+  enableQuarterHourZoom: boolean;
+  weekStartDay: WeekStartDay;
+  smoothZoom: boolean;
+}
+```
+
+Do not delete or reorder existing fields — only append the four new ones at the bottom.
+
+- [ ] **Step 2: Update default UI state**
+
+In `src/state/appStore.ts`, locate `createDefaultUI()` (around line 181) and add the four defaults to the returned object. Place them right before the closing `}`:
+
+```ts
+    uiTheme: 'default',
+    mouseWheelMode: 'zoom',
+    enableQuarterHourZoom: false,
+    weekStartDay: 'monday',
+    smoothZoom: false,
+  };
+}
+```
+
+(Keep existing `uiTheme` line; only add the four new ones.)
+
+- [ ] **Step 3: Make `setZoom` clamp dynamic**
+
+In `src/state/appStore.ts`, replace the `setZoom` action (around line 535):
+
+```ts
+    setZoom: (zoom) =>
+      set((s) => {
+        const max = s.ui.enableQuarterHourZoom ? 1000 : 400;
+        s.view.zoom = Math.max(0.5, Math.min(max, zoom));
+      }),
+```
+
+- [ ] **Step 4: Clamp existing zoom when QH-zoom is turned off**
+
+Find `setUI` in `appStore.ts` (search for `setUI: (updates`). It currently is roughly `setUI: (updates) => set((s) => { Object.assign(s.ui, updates); })`. Replace its body so that after applying updates we re-clamp `view.zoom` if needed:
+
+```ts
+    setUI: (updates) =>
+      set((s) => {
+        Object.assign(s.ui, updates);
+        const max = s.ui.enableQuarterHourZoom ? 1000 : 400;
+        if (s.view.zoom > max) s.view.zoom = max;
+      }),
+```
+
+If the existing body is structured differently (e.g. spread instead of `Object.assign`), keep the existing update mechanism and only append the clamp lines.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npm run build`
+Expected: build succeeds. If it fails on `UIState` consumers (other places that destructure UIState exhaustively), update those — there are very few.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/state/slices/types.ts src/state/appStore.ts
+git commit -m "feat(zoom): add wheel/zoom settings to UI state"
+```
+
+---
+
+## Task 2: Create the timeline tier table
+
+**Files:**
+- Create: `src/engine/renderer/timelineTiers.ts`
+
+- [ ] **Step 1: Write the file**
+
+Create `src/engine/renderer/timelineTiers.ts`:
+
+```ts
+import { addCalendarDays } from '@/utils/dateUtils';
+
+export type TimelineTier =
+  | 'year'
+  | 'quarter'
+  | 'month'
+  | 'week'
+  | 'day'
+  | 'hour'
+  | 'quarterHour';
+
+export interface TierConfig {
+  tier: TimelineTier;
+  /** Minimum pixel width a label of this tier needs to be readable. Used as a defensive skip-rule. */
+  minLabelWidth: number;
+  /**
+   * Step from one tick to the next, in fractional days.
+   * For tiers larger than a day this is approximate (months/years vary); the renderer
+   * uses the date-based "next boundary" function instead. For sub-day tiers it's exact.
+   */
+  stepDays: number;
+}
+
+export const TIER_CONFIG: Record<TimelineTier, TierConfig> = {
+  year:        { tier: 'year',        minLabelWidth: 60, stepDays: 365 },
+  quarter:     { tier: 'quarter',     minLabelWidth: 40, stepDays: 90 },
+  month:       { tier: 'month',       minLabelWidth: 50, stepDays: 30 },
+  week:        { tier: 'week',        minLabelWidth: 28, stepDays: 7 },
+  day:         { tier: 'day',         minLabelWidth: 18, stepDays: 1 },
+  hour:        { tier: 'hour',        minLabelWidth: 28, stepDays: 1 / 24 },
+  quarterHour: { tier: 'quarterHour', minLabelWidth: 28, stepDays: 1 / 96 },
+};
+
+/**
+ * Pick the {major, minor} tier pair for the given zoom (pixels per day).
+ * QH-tier is only used when enableQuarterHour is true.
+ */
+export function pickTiers(
+  zoom: number,
+  enableQuarterHour: boolean
+): { major: TimelineTier; minor: TimelineTier } {
+  if (zoom < 4) return { major: 'year', minor: 'quarter' };
+  if (zoom < 10) return { major: 'year', minor: 'month' };
+  if (zoom < 25) return { major: 'month', minor: 'week' };
+  if (zoom < 80) return { major: 'month', minor: 'day' };
+  if (zoom < 400 || !enableQuarterHour) return { major: 'day', minor: 'hour' };
+  return { major: 'hour', minor: 'quarterHour' };
+}
+
+/**
+ * Given a starting date and a tier, return the date of the next tick boundary
+ * (e.g. for 'month', the first of next month). For sub-day tiers, returns
+ * `from + stepDays`.
+ */
+export function nextTickBoundary(from: Date, tier: TimelineTier): Date {
+  switch (tier) {
+    case 'year':
+      return new Date(Date.UTC(from.getUTCFullYear() + 1, 0, 1));
+    case 'quarter': {
+      const m = from.getUTCMonth();
+      const nextQ = Math.floor(m / 3) * 3 + 3;
+      if (nextQ >= 12) return new Date(Date.UTC(from.getUTCFullYear() + 1, 0, 1));
+      return new Date(Date.UTC(from.getUTCFullYear(), nextQ, 1));
+    }
+    case 'month': {
+      const m = from.getUTCMonth();
+      if (m === 11) return new Date(Date.UTC(from.getUTCFullYear() + 1, 0, 1));
+      return new Date(Date.UTC(from.getUTCFullYear(), m + 1, 1));
+    }
+    case 'week':
+      return addCalendarDays(from, 7);
+    case 'day':
+      return addCalendarDays(from, 1);
+    case 'hour': {
+      const r = new Date(from.getTime());
+      r.setUTCHours(r.getUTCHours() + 1, 0, 0, 0);
+      return r;
+    }
+    case 'quarterHour': {
+      const r = new Date(from.getTime());
+      r.setUTCMinutes(r.getUTCMinutes() + 15, 0, 0);
+      return r;
+    }
+  }
+}
+
+/** Snap a date back to the start of its current tick (e.g. start of month). */
+export function snapToTickStart(date: Date, tier: TimelineTier, weekStartDay: 'monday' | 'sunday' = 'monday'): Date {
+  switch (tier) {
+    case 'year':
+      return new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+    case 'quarter': {
+      const m = date.getUTCMonth();
+      return new Date(Date.UTC(date.getUTCFullYear(), Math.floor(m / 3) * 3, 1));
+    }
+    case 'month':
+      return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+    case 'week': {
+      const r = new Date(date.getTime());
+      const dow = r.getUTCDay();           // 0=Sun..6=Sat
+      const offset = weekStartDay === 'sunday' ? dow : (dow === 0 ? 6 : dow - 1);
+      r.setUTCDate(r.getUTCDate() - offset);
+      r.setUTCHours(0, 0, 0, 0);
+      return r;
+    }
+    case 'day': {
+      const r = new Date(date.getTime());
+      r.setUTCHours(0, 0, 0, 0);
+      return r;
+    }
+    case 'hour': {
+      const r = new Date(date.getTime());
+      r.setUTCMinutes(0, 0, 0);
+      return r;
+    }
+    case 'quarterHour': {
+      const r = new Date(date.getTime());
+      r.setUTCMinutes(Math.floor(r.getUTCMinutes() / 15) * 15, 0, 0);
+      return r;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm run build`
+Expected: build succeeds, no errors in the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/engine/renderer/timelineTiers.ts
+git commit -m "feat(zoom): add timeline tier table and pickTiers selector"
+```
+
+---
+
+## Task 3: Add week-start-aware week number helper
+
+**Files:**
+- Modify: `src/utils/dateUtils.ts`
+
+- [ ] **Step 1: Add a Sunday-based week-start helper**
+
+In `src/utils/dateUtils.ts`, add after `getWeekStart` (around line 42):
+
+```ts
+/** Get the Sunday of the week containing the given date (used when weekStartDay='sunday') */
+export function getWeekStartSunday(d: Date): Date {
+  const result = new Date(d.getTime());
+  const dow = result.getUTCDay(); // 0=Sun..6=Sat
+  result.setUTCDate(result.getUTCDate() - dow);
+  return result;
+}
+
+/** Get the start of the week respecting the week-start-day preference */
+export function getWeekStartFor(d: Date, startDay: 'monday' | 'sunday'): Date {
+  return startDay === 'sunday' ? getWeekStartSunday(d) : getWeekStart(d);
+}
+```
+
+- [ ] **Step 2: Add a Sunday-based week-number variant**
+
+Append to the same file:
+
+```ts
+/** Get week number with configurable week start. ISO 8601 when 'monday', US-style when 'sunday'. */
+export function getWeekNumberFor(d: Date, startDay: 'monday' | 'sunday' = 'monday'): number {
+  if (startDay === 'monday') return getWeekNumber(d);
+  // US-style: week 1 contains Jan 1; weeks start Sunday.
+  const target = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const jan1 = new Date(Date.UTC(target.getUTCFullYear(), 0, 1));
+  const dayOfYear = Math.floor((target.getTime() - jan1.getTime()) / 86400000);
+  return Math.floor((dayOfYear + jan1.getUTCDay()) / 7) + 1;
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/dateUtils.ts
+git commit -m "feat(zoom): week-start-aware week-start and week-number helpers"
+```
+
+---
+
+## Task 4: Rewrite `drawTimelineHeader` to use the tier system
+
+**Files:**
+- Modify: `src/engine/renderer/GanttRenderer.ts`
+
+- [ ] **Step 1: Pass weekStartDay + enableQuarterHourZoom through render options**
+
+Find the `GanttRenderOptions` interface near the top of `GanttRenderer.ts` (search for `export interface GanttRenderOptions`) and add two fields:
+
+```ts
+export interface GanttRenderOptions {
+  // ... existing fields ...
+  weekStartDay?: 'monday' | 'sunday';        // default 'monday'
+  enableQuarterHourZoom?: boolean;            // default false
+}
+```
+
+- [ ] **Step 2: Replace `drawTimelineHeader`**
+
+Locate `private drawTimelineHeader(): void` (around line 205 — see spec). Replace the entire method body with the tier-driven version:
+
+```ts
+  private drawTimelineHeader(): void {
+    const { canvasWidth, headerHeight, taskTableWidth, view, weekStartDay, enableQuarterHourZoom, localizedMonths } = this.opts;
+    const ctx = this.ctx;
+
+    // Header background + bottom border
+    ctx.fillStyle = this.colors.headerBg;
+    ctx.fillRect(0, 0, canvasWidth, headerHeight);
+    ctx.strokeStyle = this.colors.border;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(0, headerHeight);
+    ctx.lineTo(canvasWidth, headerHeight);
+    ctx.stroke();
+
+    const wsd = weekStartDay ?? 'monday';
+    const enableQH = enableQuarterHourZoom ?? false;
+    const { major, minor } = pickTiers(view.zoom, enableQH);
+
+    // Visible date range
+    const startDate = addCalendarDays(this.viewStart, Math.floor(view.scrollX / view.zoom) - 1);
+    const endDate = addCalendarDays(this.viewStart, Math.ceil((view.scrollX + canvasWidth) / view.zoom) + 1);
+
+    // --- Top row: major tier ---
+    ctx.font = 'bold 11px -apple-system, BlinkMacSystemFont, sans-serif';
+    ctx.fillStyle = this.colors.text;
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'left';
+    this.drawTierLabels(major, startDate, endDate, taskTableWidth, headerHeight / 4, wsd, localizedMonths);
+
+    // --- Bottom row: minor tier ---
+    ctx.font = '10px -apple-system, BlinkMacSystemFont, sans-serif';
+    ctx.fillStyle = this.colors.textSecondary;
+    this.drawTierLabels(minor, startDate, endDate, taskTableWidth, headerHeight * 3 / 4, wsd, localizedMonths);
+  }
+
+  private drawTierLabels(
+    tier: TimelineTier,
+    startDate: Date,
+    endDate: Date,
+    taskTableWidth: number,
+    yCenter: number,
+    weekStartDay: 'monday' | 'sunday',
+    localizedMonths?: string[]
+  ): void {
+    const { canvasWidth } = this.opts;
+    const ctx = this.ctx;
+    const cfg = TIER_CONFIG[tier];
+
+    // Snap to the tick boundary at-or-before startDate
+    let cursor = snapToTickStart(startDate, tier, weekStartDay);
+    let lastDrawnRight = -Infinity;
+
+    while (cursor.getTime() <= endDate.getTime()) {
+      const next = nextTickBoundary(cursor, tier);
+      const x1 = this.dateToXMs(cursor);
+      const x2 = this.dateToXMs(next);
+      const labelText = this.formatTierLabel(tier, cursor, weekStartDay, localizedMonths);
+
+      // Skip tick entirely if it doesn't reach the visible task area
+      if (x2 <= taskTableWidth) {
+        cursor = next;
+        continue;
+      }
+      // Stop once we're past the right edge
+      if (x1 >= canvasWidth) break;
+
+      const labelX = Math.max(x1 + 4, taskTableWidth + 4);
+      const slotWidth = x2 - Math.max(x1, taskTableWidth);
+
+      // Defensive skip: if slot is too narrow OR we'd overlap the previous label
+      if (slotWidth >= cfg.minLabelWidth && labelX > lastDrawnRight + 4) {
+        ctx.fillText(labelText, labelX, yCenter);
+        const measured = ctx.measureText(labelText).width;
+        lastDrawnRight = labelX + measured;
+      }
+
+      cursor = next;
+    }
+  }
+
+  private formatTierLabel(
+    tier: TimelineTier,
+    d: Date,
+    weekStartDay: 'monday' | 'sunday',
+    localizedMonths?: string[]
+  ): string {
+    const months = localizedMonths || ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    switch (tier) {
+      case 'year':        return `${d.getUTCFullYear()}`;
+      case 'quarter':     return `Q${Math.floor(d.getUTCMonth() / 3) + 1} ${d.getUTCFullYear()}`;
+      case 'month':       return `${months[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+      case 'week':        return `W${getWeekNumberFor(d, weekStartDay)}`;
+      case 'day':         return `${d.getUTCDate()}`;
+      case 'hour':        return `${pad(d.getUTCHours())}:00`;
+      case 'quarterHour': return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+    }
+  }
+
+  /** Convert a Date (with possible sub-day precision) to canvas X. */
+  private dateToXMs(date: Date): number {
+    const msPerDay = 86400000;
+    const daysFromStart = (date.getTime() - this.viewStart.getTime()) / msPerDay;
+    return this.opts.taskTableWidth + daysFromStart * this.opts.view.zoom - this.opts.view.scrollX;
+  }
+```
+
+- [ ] **Step 3: Add the imports**
+
+At the top of `GanttRenderer.ts`, add:
+
+```ts
+import { TimelineTier, TIER_CONFIG, pickTiers, nextTickBoundary, snapToTickStart } from './timelineTiers';
+import { getWeekNumberFor } from '@/utils/dateUtils';
+```
+
+(Keep existing imports.)
+
+- [ ] **Step 4: Remove the now-unused fixed weekday vertical-grid logic**
+
+Inside the `render()` method (around line 168) the current code thickens the grid line on Mondays via `dayOfWeek === 1 ? 1 : 0.5`. Replace that single ternary so it respects week-start-day:
+
+```ts
+ctx.lineWidth = dayOfWeek === (this.opts.weekStartDay === 'sunday' ? 7 : 1) ? 1 : 0.5;
+```
+
+(`isoDayOfWeek` returns 7 for Sunday, 1 for Monday.)
+
+- [ ] **Step 5: Type-check**
+
+Run: `npm run build`
+Expected: success. If TS complains about new option fields being optional, add `weekStartDay: 'monday'` defaults at the call site (handled in Task 5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/engine/renderer/GanttRenderer.ts
+git commit -m "feat(zoom): tier-driven timeline header with week-start support"
+```
+
+---
+
+## Task 5: Wire renderer options + remove inline wheel handler in GanttCanvas
+
+**Files:**
+- Modify: `src/components/canvas/GanttCanvas.tsx`
+
+- [ ] **Step 1: Read the new UI fields**
+
+Near the existing `useAppStore` selectors (around line 73 — `const uiTheme = useAppStore(s => s.ui.uiTheme);`) add:
+
+```ts
+const weekStartDay = useAppStore(s => s.ui.weekStartDay);
+const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
+const mouseWheelMode = useAppStore(s => s.ui.mouseWheelMode);
+const smoothZoom = useAppStore(s => s.ui.smoothZoom);
+```
+
+- [ ] **Step 2: Pass them through render options**
+
+In the `render` callback (around line 138), include them in `opts`:
+
+```ts
+const opts: GanttRenderOptions = {
+  // ... existing fields ...
+  columnHeaders,
+  weekStartDay,
+  enableQuarterHourZoom,
+};
+```
+
+Update the dependency array of the `useCallback` (line 157) to include `weekStartDay` and `enableQuarterHourZoom`.
+
+- [ ] **Step 3: Delete the inline wheel handler effect**
+
+Delete the entire effect block "Native wheel handler to prevent browser zoom on ctrl+scroll" (lines 177–197 of the file before this task; the block starts with the comment and ends with the empty line after `}, [view.zoom, view.scrollX, view.scrollY, setZoom, setScroll]);`).
+
+- [ ] **Step 4: Type-check**
+
+Run: `npm run build`
+Expected: success. The header will render via the new tier system; wheel behavior is temporarily broken until Task 6 wires the new hook.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/canvas/GanttCanvas.tsx
+git commit -m "refactor(zoom): pass tier options to renderer, drop inline wheel effect"
+```
+
+---
+
+## Task 6: Build the zoom hook with cursor anchoring
+
+**Files:**
+- Create: `src/hooks/useGanttZoom.ts`
+
+- [ ] **Step 1: Write the hook**
+
+Create `src/hooks/useGanttZoom.ts`:
+
+```ts
+import { useEffect, useRef } from 'react';
+import { useAppStore } from '@/state/appStore';
+
+interface UseGanttZoomOpts {
+  containerRef: React.RefObject<HTMLDivElement>;
+  taskTableWidth: number;
+}
+
+const ZOOM_FACTOR_PER_TICK = 1.1;
+const ANIM_DURATION_MS = 180;
+
+export function useGanttZoom({ containerRef, taskTableWidth }: UseGanttZoomOpts) {
+  const view = useAppStore(s => s.view);
+  const setZoom = useAppStore(s => s.setZoom);
+  const setScroll = useAppStore(s => s.setScroll);
+  const mouseWheelMode = useAppStore(s => s.ui.mouseWheelMode);
+  const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
+  const smoothZoom = useAppStore(s => s.ui.smoothZoom);
+
+  // Latest values in a ref so the wheel handler doesn't re-attach every render
+  const latest = useRef({ view, mouseWheelMode, enableQuarterHourZoom, smoothZoom });
+  latest.current = { view, mouseWheelMode, enableQuarterHourZoom, smoothZoom };
+
+  const animRef = useRef<number | null>(null);
+
+  // Cursor-anchored zoom step. anchorX is canvas-X (pixels from canvas left edge).
+  const zoomAt = (newZoom: number, anchorX: number) => {
+    const { view: v, enableQuarterHourZoom: enableQH } = latest.current;
+    const max = enableQH ? 1000 : 400;
+    const clamped = Math.max(0.5, Math.min(max, newZoom));
+    if (clamped === v.zoom) return;
+
+    // Date under the cursor at current zoom (in fractional days from viewStart)
+    const localX = anchorX - taskTableWidth + v.scrollX;
+    const daysUnderCursor = localX / v.zoom;
+
+    // New scrollX so the same fractional day stays under the cursor
+    const newScrollX = Math.max(0, daysUnderCursor * clamped - (anchorX - taskTableWidth));
+
+    if (latest.current.smoothZoom) {
+      animateTo(clamped, newScrollX);
+    } else {
+      setZoom(clamped);
+      setScroll(newScrollX, v.scrollY);
+    }
+  };
+
+  const animateTo = (targetZoom: number, targetScrollX: number) => {
+    if (animRef.current !== null) cancelAnimationFrame(animRef.current);
+    const startZoom = latest.current.view.zoom;
+    const startScrollX = latest.current.view.scrollX;
+    const startTime = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - startTime) / ANIM_DURATION_MS);
+      const eased = 1 - Math.pow(1 - t, 3); // ease-out-cubic
+      const z = startZoom + (targetZoom - startZoom) * eased;
+      const x = startScrollX + (targetScrollX - startScrollX) * eased;
+      setZoom(z);
+      setScroll(x, latest.current.view.scrollY);
+      if (t < 1) animRef.current = requestAnimationFrame(tick);
+      else animRef.current = null;
+    };
+    animRef.current = requestAnimationFrame(tick);
+  };
+
+  // Wheel handler
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = container.getBoundingClientRect();
+      const anchorX = e.clientX - rect.left;
+      const { mouseWheelMode: mode, view: v } = latest.current;
+
+      const isZoomGesture =
+        e.ctrlKey || e.metaKey ||
+        (mode === 'zoom' && !e.shiftKey);
+
+      if (isZoomGesture) {
+        const factor = e.deltaY > 0 ? 1 / ZOOM_FACTOR_PER_TICK : ZOOM_FACTOR_PER_TICK;
+        zoomAt(v.zoom * factor, anchorX);
+        return;
+      }
+
+      // Scroll path
+      if (mode === 'zoom' && e.shiftKey) {
+        // Shift+wheel scrolls horizontally
+        setScroll(v.scrollX + e.deltaY, v.scrollY);
+      } else if (mode === 'scroll') {
+        if (e.shiftKey) {
+          setScroll(v.scrollX + e.deltaY, v.scrollY);
+        } else {
+          setScroll(v.scrollX + e.deltaX, v.scrollY + e.deltaY);
+        }
+      }
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+      if (animRef.current !== null) cancelAnimationFrame(animRef.current);
+    };
+  }, [containerRef, taskTableWidth, setZoom, setScroll]);
+
+  return { zoomAt };
+}
+```
+
+- [ ] **Step 2: Use the hook in `GanttCanvas`**
+
+In `src/components/canvas/GanttCanvas.tsx`, near the other hooks (just below the `useAppStore` selectors), add:
+
+```ts
+import { useGanttZoom } from '@/hooks/useGanttZoom';
+
+// ... inside the component, after other refs/selectors:
+const { zoomAt } = useGanttZoom({ containerRef, taskTableWidth: TASK_TABLE_WIDTH });
+```
+
+- [ ] **Step 3: Type-check + smoke test in dev**
+
+Run: `npm run build` (must pass)
+Then: `./node_modules/.bin/vite --host` (or have dev server running) — open the app and verify:
+1. Plain mouse wheel over the canvas zooms (not scrolls).
+2. The point under the cursor stays under the cursor when you zoom.
+3. Ctrl+wheel also zooms.
+4. Shift+wheel scrolls horizontally.
+
+If any of these fail, debug before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useGanttZoom.ts src/components/canvas/GanttCanvas.tsx
+git commit -m "feat(zoom): cursor-anchored zoom with smooth-zoom + wheel-mode support"
+```
+
+---
+
+## Task 7: Fix horizontal scroll bug
+
+**Files:**
+- Modify: `src/components/canvas/GanttCanvas.tsx`
+
+The bug: when zoom changes (or after `zoomAt`), the hidden hScroll element's `scrollLeft` becomes inconsistent with the new content width and the new `view.scrollX`. The existing sync effect (around line 200) only fires when `scrollX` changes, not when `zoom` (and therefore `totalContentWidth`) changes.
+
+- [ ] **Step 1: Sync hScroll on both scrollX and zoom changes**
+
+In `src/components/canvas/GanttCanvas.tsx`, find the effect "Sync horizontal scrollbar with canvas scrollX" (around line 200) and update its body and dependency array:
+
+```ts
+// Sync horizontal scrollbar with canvas scrollX (also re-sync after zoom changes)
+useEffect(() => {
+  const hScroll = hScrollRef.current;
+  if (!hScroll) return;
+  const desired = view.scrollX;
+  if (Math.abs(hScroll.scrollLeft - desired) > 1) {
+    hScroll.scrollLeft = desired;
+  }
+}, [view.scrollX, view.zoom]);
+```
+
+- [ ] **Step 2: Manually verify**
+
+Run dev server. Reproduce the original bug:
+1. Add some tasks if none exist.
+2. Zoom in twice (wheel up over the canvas) — verify tasks remain visible and the header stays aligned.
+3. Drag the horizontal scrollbar — verify tasks AND header move together.
+4. Zoom in further while scrolled, then scroll back to start — verify everything still aligns.
+
+If any step fails, investigate. Likely culprits: stale `viewStart` in the renderer (cached on construction), or `totalContentWidth` not recomputing because it doesn't depend on `scrollX`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/canvas/GanttCanvas.tsx
+git commit -m "fix(zoom): re-sync horizontal scrollbar after zoom changes"
+```
+
+---
+
+## Task 8: Add keyboard shortcuts
+
+**Files:**
+- Create: `src/hooks/useZoomShortcuts.ts`
+- Modify: `src/components/canvas/GanttCanvas.tsx`
+
+- [ ] **Step 1: Write the hook**
+
+Create `src/hooks/useZoomShortcuts.ts`:
+
+```ts
+import { useEffect } from 'react';
+import { useAppStore } from '@/state/appStore';
+import { parseDate, diffCalendarDays } from '@/utils/dateUtils';
+
+interface UseZoomShortcutsOpts {
+  zoomAt: (newZoom: number, anchorX: number) => void;
+  containerRef: React.RefObject<HTMLDivElement>;
+  taskTableWidth: number;
+}
+
+const DEFAULT_ZOOM = 30;
+
+export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZoomShortcutsOpts) {
+  const setZoom = useAppStore(s => s.setZoom);
+  const setScroll = useAppStore(s => s.setScroll);
+  const setViewStartDate = useAppStore(s => s.setViewStartDate);
+  const tasks = useAppStore(s => s.tasks);
+  const view = useAppStore(s => s.view);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Don't intercept while typing in an input/textarea
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const centerX = rect.width / 2;
+
+      if ((e.key === '+' || e.key === '=') && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        zoomAt(view.zoom * 1.1, centerX);
+      } else if (e.key === '-' && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        zoomAt(view.zoom / 1.1, centerX);
+      } else if (e.key === '0' && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        setZoom(DEFAULT_ZOOM);
+        setScroll(0, view.scrollY);
+      } else if (e.key === '0' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        // Fit to project
+        if (tasks.length === 0) {
+          setZoom(DEFAULT_ZOOM);
+          setScroll(0, view.scrollY);
+          return;
+        }
+        let minStart: string | null = null;
+        let maxFinish: string | null = null;
+        for (const t of tasks) {
+          const s = t.time.earlyStart || t.time.scheduleStart;
+          const f = t.time.earlyFinish || t.time.scheduleFinish || s;
+          if (s && (!minStart || s < minStart)) minStart = s;
+          if (f && (!maxFinish || f > maxFinish)) maxFinish = f;
+        }
+        if (!minStart || !maxFinish) return;
+        const span = Math.max(1, diffCalendarDays(parseDate(minStart), parseDate(maxFinish)) + 1);
+        const usable = rect.width - taskTableWidth;
+        if (usable <= 0) return;
+        const newZoom = Math.max(0.5, Math.min(400, usable / span));
+        setZoom(newZoom);
+        setViewStartDate(minStart);
+        setScroll(0, view.scrollY);
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [zoomAt, containerRef, taskTableWidth, setZoom, setScroll, setViewStartDate, view.zoom, view.scrollY, tasks]);
+}
+```
+
+- [ ] **Step 2: Use the hook**
+
+In `src/components/canvas/GanttCanvas.tsx`, near the other hook calls:
+
+```ts
+import { useZoomShortcuts } from '@/hooks/useZoomShortcuts';
+
+// ... after `const { zoomAt } = useGanttZoom(...)`:
+useZoomShortcuts({ zoomAt, containerRef, taskTableWidth: TASK_TABLE_WIDTH });
+```
+
+- [ ] **Step 3: Manual verify**
+
+Reload dev server. With the canvas focused (click anywhere on the gantt area first to give window focus):
+1. Press `+` → zoom in.
+2. Press `-` → zoom out.
+3. Press `0` → resets to default zoom 30.
+4. Press `Ctrl+0` → fits all tasks horizontally.
+5. Type in the task-name dialog (TaskDialog open) → `+`/`-` should NOT zoom.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useZoomShortcuts.ts src/components/canvas/GanttCanvas.tsx
+git commit -m "feat(zoom): keyboard shortcuts (+/-/0/Ctrl+0 fit-to-project)"
+```
+
+---
+
+## Task 9: Add settings UI
+
+**Files:**
+- Modify: `src/components/dialogs/SettingsDialog.tsx`
+- Modify: `src/i18n/locales/nl/common.json`
+- Modify: `src/i18n/locales/en/common.json`
+
+- [ ] **Step 1: Add translations (Dutch)**
+
+In `src/i18n/locales/nl/common.json`, extend the `settings` block with new keys (place them right after `"theme": "Thema"` and before the closing brace):
+
+```json
+    "theme": "Thema",
+    "timeline": "Tijdlijn / Zoomen",
+    "mouseWheelMode": "Muiswiel-gedrag",
+    "mouseWheelModeZoom": "Zoomen",
+    "mouseWheelModeScroll": "Scrollen",
+    "enableQuarterHourZoom": "Kwartieren tonen bij ver inzoomen",
+    "weekStartDay": "Week begint op",
+    "weekStartMonday": "Maandag",
+    "weekStartSunday": "Zondag",
+    "smoothZoom": "Vloeiende zoom-animatie"
+  }
+```
+
+- [ ] **Step 2: Add translations (English)**
+
+In `src/i18n/locales/en/common.json`, extend the `settings` block analogously:
+
+```json
+    "theme": "Theme",
+    "timeline": "Timeline / Zoom",
+    "mouseWheelMode": "Mouse wheel behavior",
+    "mouseWheelModeZoom": "Zoom",
+    "mouseWheelModeScroll": "Scroll",
+    "enableQuarterHourZoom": "Show quarter-hours when zoomed in far",
+    "weekStartDay": "Week starts on",
+    "weekStartMonday": "Monday",
+    "weekStartSunday": "Sunday",
+    "smoothZoom": "Smooth zoom animation"
+  }
+```
+
+(Other languages will fall back to English via i18next.)
+
+- [ ] **Step 3: Add a "Tijdlijn" tab + section to SettingsDialog**
+
+In `src/components/dialogs/SettingsDialog.tsx`, extend the tab type:
+
+```ts
+type SettingsTab = 'general' | 'language' | 'timeline';
+```
+
+Add the new selectors near the top of the component:
+
+```ts
+const mouseWheelMode = useAppStore(s => s.ui.mouseWheelMode);
+const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
+const weekStartDay = useAppStore(s => s.ui.weekStartDay);
+const smoothZoom = useAppStore(s => s.ui.smoothZoom);
+```
+
+Add a new tab button next to the existing two (around line 93):
+
+```tsx
+<button
+  className={`settings-tab ${activeTab === 'timeline' ? 'active' : ''}`}
+  onClick={() => setActiveTab('timeline')}
+>
+  {t('settings.timeline')}
+</button>
+```
+
+Add the corresponding tab content block right after the `language` block (around line 142):
+
+```tsx
+{activeTab === 'timeline' && (
+  <div className="settings-section-list">
+    <div className="settings-section">
+      <h3>{t('settings.mouseWheelMode')}</h3>
+      <select
+        className="settings-select"
+        value={mouseWheelMode}
+        onChange={e => setUI({ mouseWheelMode: e.target.value as 'zoom' | 'scroll' })}
+      >
+        <option value="zoom">{t('settings.mouseWheelModeZoom')}</option>
+        <option value="scroll">{t('settings.mouseWheelModeScroll')}</option>
+      </select>
+    </div>
+    <div className="settings-section">
+      <h3>{t('settings.weekStartDay')}</h3>
+      <select
+        className="settings-select"
+        value={weekStartDay}
+        onChange={e => setUI({ weekStartDay: e.target.value as 'monday' | 'sunday' })}
+      >
+        <option value="monday">{t('settings.weekStartMonday')}</option>
+        <option value="sunday">{t('settings.weekStartSunday')}</option>
+      </select>
+    </div>
+    <div className="settings-section">
+      <label className="settings-row" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <input
+          type="checkbox"
+          checked={enableQuarterHourZoom}
+          onChange={e => setUI({ enableQuarterHourZoom: e.target.checked })}
+        />
+        <span>{t('settings.enableQuarterHourZoom')}</span>
+      </label>
+    </div>
+    <div className="settings-section">
+      <label className="settings-row" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <input
+          type="checkbox"
+          checked={smoothZoom}
+          onChange={e => setUI({ smoothZoom: e.target.checked })}
+        />
+        <span>{t('settings.smoothZoom')}</span>
+      </label>
+    </div>
+  </div>
+)}
+```
+
+(`setUI` writes immediately to the store — no separate "save" needed for these settings; they take effect live.)
+
+- [ ] **Step 4: Manual verify**
+
+Reload dev server. Open Settings → "Tijdlijn / Zoomen":
+1. All four controls render correctly with Dutch labels.
+2. Toggling "Muiswiel-gedrag" to *Scrollen* makes plain wheel scroll instead of zoom (Ctrl+wheel still zooms).
+3. Toggling "Kwartieren tonen…" on lets you zoom past 400 px/day and see HH:MM labels.
+4. Toggling "Week begint op" to Sunday changes week numbers and the thicker grid line moves to Sunday.
+5. Toggling "Vloeiende zoom-animatie" makes the zoom step animate (~180 ms).
+
+- [ ] **Step 5: Type-check**
+
+Run: `npm run build`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/dialogs/SettingsDialog.tsx src/i18n/locales/nl/common.json src/i18n/locales/en/common.json
+git commit -m "feat(zoom): settings UI — wheel mode, QH zoom, week start, smooth zoom"
+```
+
+---
+
+## Task 10: Final regression check + cleanup
+
+- [ ] **Step 1: Full manual regression**
+
+Reload dev server and walk through:
+
+1. Default state: header shows month + day labels, plain wheel zooms toward cursor.
+2. Zoom out fully (wheel down many ticks): header transitions to month/week, then year/month, then year/quarter — no overlapping labels at any point.
+3. Zoom in past 80 px/day: header shows day + hour labels.
+4. Toggle quarter-hour setting on, zoom further in: header shows hour + 15-minute labels at zoom > 400.
+5. `Ctrl+0`: fits the project to screen.
+6. Drag horizontal scrollbar: tasks and header move together at any zoom.
+7. Switch to Sunday week start: weekday-grid emphasis moves, week numbers shift.
+8. Settings dialog still saves theme + language correctly (regression of pre-existing behavior).
+
+- [ ] **Step 2: Type-check**
+
+Run: `npm run build`
+Expected: success, no TypeScript errors.
+
+- [ ] **Step 3: Final commit (only if any cleanup was needed)**
+
+If the regression revealed small fixes, commit them with a clear message. Otherwise skip.
+
+```bash
+# Only if there are pending changes:
+git add -A
+git commit -m "fix(zoom): regression cleanups from final pass"
+```
+
+---
+
+## Notes / Known Gotchas
+
+- The renderer's `viewStart` is captured when `GanttRenderer` is constructed (once per render call). Since `GanttCanvas`'s `render` callback creates a fresh renderer every frame, this is fine — but if anyone refactors to reuse a renderer instance, `viewStart` must be kept in sync with `view.viewStartDate`.
+- `setZoom` clamps; consumers calling it with extreme values (e.g. during fit-to-project on a 50-year project) will silently get the clamp value. The fit-to-project code re-clamps explicitly for safety.
+- i18next falls back to the English bundle when a key is missing in the active locale; the 12 untranslated locales will show English strings for the new settings until someone provides translations.
+- During smooth-zoom animation, `zoomAt` writes many small store updates per frame. Zustand+Immer batches re-renders fine, but if performance suffers, switch the animation to update via a single ref + manual repaint instead.

--- a/docs/superpowers/specs/2026-05-01-zoom-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-01-zoom-improvements-design.md
@@ -1,0 +1,161 @@
+# Zoom improvements — design
+
+Date: 2026-05-01
+Status: approved (pending implementation plan)
+
+## Goal
+
+Make timeline zooming feel like CAD: plain mouse wheel zooms toward the cursor, the header gracefully adapts from years down to quarter-hours, the existing glitch when zoomed out is gone, and horizontal scrolling actually works. Behavior is configurable in Settings.
+
+## Scope
+
+In scope:
+- Mouse wheel zoom (configurable: zoom on plain wheel, or scroll on plain wheel)
+- Zoom-toward-cursor (always on)
+- Adaptive timeline header with discrete tiers (year / quarter / month / week / day / hour / quarter-hour)
+- Optional quarter-hour tier (Settings toggle, default off)
+- Configurable week start (Monday / Sunday)
+- Bug fix: header glitches at low zoom levels
+- Bug fix: horizontal scroll loses tasks and header doesn't follow
+- Keyboard shortcuts: `+`, `-`, `0` (reset), `Ctrl+0` (fit to project)
+- Optional smooth zoom animation (Settings toggle, default off)
+
+Out of scope:
+- Toolbar zoom buttons / current-zoom label (item a)
+- Per-project saved zoom (item d)
+- Touchpad pinch-to-zoom (item e)
+- Floating zoom indicator (item f)
+- Sub-day task scheduling — header may show hours but task durations remain whole-day for now
+
+## Architecture
+
+### New files
+
+- `src/engine/renderer/timelineTiers.ts` — pure data: tier table with `{ tier, minLabelWidth, format(date) }` for `year`, `quarter`, `month`, `week`, `day`, `hour`, `quarterHour`. Plus a `pickTiers(zoom, enableQuarterHour) → { major, minor }` helper. The selection rule (below) decides which tiers are shown at which zoom; `minLabelWidth` is only used at render-time to skip labels that don't fit (defensive — should rarely trigger given pickTiers is conservative).
+- `src/hooks/useGanttZoom.ts` — owns the wheel handler and the cursor-anchored zoom math. Reads `settings.mouseWheelMode`, `settings.enableQuarterHourZoom`, `settings.smoothZoom`. Exposes a `zoomAt(targetZoom, anchorX)` function used by both wheel and keyboard.
+- `src/hooks/useZoomShortcuts.ts` — keyboard shortcuts (`+`, `-`, `0`, `Ctrl+0` fit-to-project). Calls into `useGanttZoom`.
+
+### Changed files
+
+- `src/engine/renderer/GanttRenderer.ts` — `drawTimelineHeader` rewritten to read from the tier table. Two-row header (major top, minor bottom). Labels are skipped when their pixel width drops below the tier's `minLabelWidth`.
+- `src/components/canvas/GanttCanvas.tsx` — wheel effect removed; replaced by `useGanttZoom()` and `useZoomShortcuts()` calls. Horizontal scroll bug investigated and fixed (see "Bug 4b" below).
+- `src/state/slices/types.ts` + `src/state/appStore.ts`:
+  - Add to `settings`: `mouseWheelMode: 'zoom' | 'scroll'` (default `'zoom'`), `enableQuarterHourZoom: boolean` (default `false`), `weekStartDay: 'monday' | 'sunday'` (default `'monday'`), `smoothZoom: boolean` (default `false`).
+  - `setZoom` clamp range becomes dynamic: max = 1000 if `enableQuarterHourZoom` else 400. Min stays at 0.5 (slightly below current 1 so jaar-niveau echt past).
+  - When the user toggles `enableQuarterHourZoom` off while `view.zoom > 400`, clamp `view.zoom` to 400.
+- `src/components/dialogs/SettingsDialog.tsx` — new section "Tijdlijn / Zoomen" with the four toggles.
+- `src/utils/dateUtils.ts` — `getWeekNumber` and `isoDayOfWeek` already produce ISO-week (Monday-based). Add `getWeekNumber(date, startDay)` overload that returns Sunday-based week numbers when configured. Existing callers default to Monday.
+
+## Tier table (concrete values)
+
+```
+{ tier: 'year',        minLabelWidth: 60,  format: d => `${year(d)}` }
+{ tier: 'quarter',     minLabelWidth: 40,  format: d => `Q${quarter(d)} ${year(d)}` }
+{ tier: 'month',       minLabelWidth: 50,  format: d => `${monthName(d)} ${year(d)}` }
+{ tier: 'week',        minLabelWidth: 28,  format: d => `W${weekNum(d)}` }
+{ tier: 'day',         minLabelWidth: 18,  format: d => `${day(d)}` }
+{ tier: 'hour',        minLabelWidth: 28,  format: d => `${hh(d)}:00` }
+{ tier: 'quarterHour', minLabelWidth: 28,  format: d => `${hh(d)}:${mm(d)}` }
+```
+
+`pickTiers(zoom, enableQH)` returns `{ major, minor }`:
+- `zoom < 4`: `{ year, quarter }`
+- `4 ≤ zoom < 10`: `{ year, month }`
+- `10 ≤ zoom < 25`: `{ month, week }`
+- `25 ≤ zoom < 80`: `{ month, day }`
+- `80 ≤ zoom < 400` (or zoom ≥ 400 and enableQH off): `{ day, hour }`
+- `zoom ≥ 400` and enableQH on: `{ hour, quarterHour }`
+
+## Cursor-anchored zoom
+
+`zoomAt(newZoom, anchorX)`:
+
+1. `dateUnderCursor = view.viewStartDate + (anchorX - taskTableWidth + view.scrollX) / view.zoom` (in fractional days).
+2. Clamp `newZoom` to `[0.5, maxZoom]`.
+3. Compute new `scrollX` so the same date stays under `anchorX`:
+   `newScrollX = dateUnderCursor * newZoom - (anchorX - taskTableWidth)`
+4. Apply both in a single store update so React re-renders once.
+
+Wheel-tick zoom factor is 1.1 per tick (`newZoom = view.zoom * (deltaY > 0 ? 1/1.1 : 1.1)`).
+
+For toolbar / keyboard "+" / "-": `anchorX = canvasWidth / 2 + taskTableWidth / 2` (visible area center).
+
+For `Ctrl+0` fit-to-project: compute project span (earliest start → latest finish). If there are no tasks, behave as `0` (reset). Otherwise set `zoom = (canvasWidth - taskTableWidth) / spanInDays` clamped to `[0.5, maxZoom]`, `scrollX = 0`, `viewStartDate = earliestStart`.
+
+For `0` reset: `zoom = 30` (default), `scrollX = 0`.
+
+## Wheel handler behavior
+
+```
+mouseWheelMode = 'zoom':
+  plain wheel:    zoom (anchored to cursor)
+  Shift + wheel:  scroll horizontally
+  Ctrl + wheel:   zoom (alias, anchored to cursor)
+
+mouseWheelMode = 'scroll':
+  plain wheel:    scroll vertically (deltaY) and horizontally (deltaX)
+  Shift + wheel:  scroll horizontally (deltaY mapped to X)
+  Ctrl + wheel:   zoom (anchored to cursor)
+```
+
+Zoom-toward-cursor is always on regardless of mode.
+
+## Smooth zoom animation
+
+When `settings.smoothZoom` is on: `zoomAt` interpolates `view.zoom` and `view.scrollX` over 180 ms with `ease-out-cubic`, using `requestAnimationFrame`. Multiple wheel-ticks while an animation is mid-flight cancel the previous animation and restart from the current interpolated values (no queueing).
+
+When off: instant update (current behavior).
+
+## Settings dialog
+
+New section "Tijdlijn / Zoomen" with:
+
+- Radio: **Muiswiel-gedrag** — Zoomen (default) / Scrollen
+- Toggle: **Kwartieren tonen bij ver inzoomen** (default off)
+- Radio: **Week begint op** — Maandag (default) / Zondag
+- Toggle: **Vloeiende zoom-animatie** (default off)
+
+## Keyboard shortcuts
+
+Registered in `useZoomShortcuts` (active when canvas has focus or no input is focused):
+
+- `+` / `=`: zoom in one step (factor 1.1, anchor = canvas center)
+- `-`: zoom out one step (factor 1/1.1)
+- `0`: reset zoom to 30 px/day, scrollX to 0
+- `Ctrl+0`: fit to project (see above)
+
+## Bug fixes
+
+### Bug 4 — header glitch at low zoom
+
+Root cause: at very low zoom the existing renderer draws a label every time `month !== lastMonth`, but consecutive months are < 30 px apart, so labels overlap and become unreadable.
+
+Fix: handled by the tier system. Each tier has a `minLabelWidth`; `pickTiers` ensures the active tier always has enough room. When labels would still collide (e.g. very narrow window), the renderer skips a label if the previous label's right edge has not passed yet.
+
+### Bug 4b — horizontal scroll breaks tasks/header
+
+Investigation needed during implementation. Suspected cause: `totalContentWidth` (in `GanttCanvas.tsx`) recomputes on zoom but the hidden scroll-bar's `scrollLeft` is not re-clamped, so `view.scrollX` in the store stays stale relative to what the canvas paints. The renderer reads `scrollX` from the store, not from the scroll-bar element — but the scroll-bar's `onScroll` may not fire after a zoom change.
+
+Fix plan:
+1. Make the scroll-bar element the single source of truth for `scrollX`. After any zoom change, programmatically set `hScrollRef.current.scrollLeft = view.scrollX` and rely on `onScroll` to keep the store in sync.
+2. Header rendering in `GanttRenderer.drawTimelineHeader` already uses `view.scrollX`; verify it isn't reading a stale closure value via the renderer instance.
+3. Add a regression check: scroll horizontally to day 200, zoom in twice, scroll back — task bars and header should always stay aligned.
+
+If investigation reveals a different cause, document the actual fix in the implementation plan.
+
+## Testing
+
+Manual verification (no automated tests for canvas rendering exist):
+
+1. Plain wheel zooms toward cursor at every zoom level.
+2. Switching `mouseWheelMode` to "Scrollen" makes plain wheel scroll, Ctrl+wheel zoom.
+3. Header transitions smoothly at zoom thresholds 1.5, 4, 10, 25, 80, 400 (when QH enabled).
+4. Zooming out to minimum doesn't produce overlapping labels (bug 4 gone).
+5. Horizontal scroll keeps tasks and header aligned at any zoom (bug 4b gone).
+6. `Ctrl+0` fits the entire project to the visible area.
+7. Week-start setting flips weekday markers and week numbers correctly.
+8. Smooth-zoom toggle visibly changes feel; instant when off.
+
+## Open questions
+
+None — decisions captured above.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { initLocale } from '@/i18n/config';
-import { initTheme } from '@/utils/settingsStore';
+import { initTheme, loadZoomSettings } from '@/utils/settingsStore';
 import { writeIFC } from '@/services/ifc/ifcWriter';
 import { readIFC } from '@/services/ifc/ifcReader';
 const isTauri = () => '__TAURI_INTERNALS__' in window;
@@ -40,6 +40,9 @@ function AppContent() {
     initLocale();
     initTheme().then(theme => {
       setUI({ uiTheme: theme as any });
+    });
+    loadZoomSettings().then(zs => {
+      if (Object.keys(zs).length > 0) setUI(zs);
     });
   }, []);
 

--- a/src/components/canvas/GanttCanvas.tsx
+++ b/src/components/canvas/GanttCanvas.tsx
@@ -67,10 +67,11 @@ export function GanttCanvas() {
   const updateTask = useAppStore(s => s.updateTask);
   const deleteTask = useAppStore(s => s.deleteTask);
   const setScroll = useAppStore(s => s.setScroll);
-  const setZoom = useAppStore(s => s.setZoom);
   const setUI = useAppStore(s => s.setUI);
   const project = useAppStore(s => s.project);
   const uiTheme = useAppStore(s => s.ui.uiTheme);
+  const weekStartDay = useAppStore(s => s.ui.weekStartDay);
+  const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
   const cpmResult = useAppStore(s => s.cpmResult);
 
   const rendererRef = useRef<GanttRenderer | null>(null);
@@ -149,12 +150,14 @@ export function GanttCanvas() {
       headerHeight: HEADER_HEIGHT,
       localizedMonths,
       columnHeaders,
+      weekStartDay,
+      enableQuarterHourZoom,
     };
 
     const renderer = new GanttRenderer(ctx, opts);
     rendererRef.current = renderer;
     renderer.render();
-  }, [tasks, sequences, calendar, view, selectedTaskIds, collapsedTaskIds, localizedMonths, columnHeaders, uiTheme]);
+  }, [tasks, sequences, calendar, view, selectedTaskIds, collapsedTaskIds, localizedMonths, columnHeaders, uiTheme, weekStartDay, enableQuarterHourZoom]);
 
   // Render on changes
   useEffect(() => {
@@ -173,28 +176,6 @@ export function GanttCanvas() {
     observer.observe(container);
     return () => observer.disconnect();
   }, [render]);
-
-  // Native wheel handler to prevent browser zoom on ctrl+scroll
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const handleWheel = (e: WheelEvent) => {
-      e.preventDefault();
-
-      if (e.ctrlKey || e.metaKey) {
-        const delta = e.deltaY > 0 ? -5 : 5;
-        setZoom(view.zoom + delta);
-      } else if (e.shiftKey) {
-        setScroll(view.scrollX + e.deltaY, view.scrollY);
-      } else {
-        setScroll(view.scrollX + e.deltaX, view.scrollY + e.deltaY);
-      }
-    };
-
-    container.addEventListener('wheel', handleWheel, { passive: false });
-    return () => container.removeEventListener('wheel', handleWheel);
-  }, [view.zoom, view.scrollX, view.scrollY, setZoom, setScroll]);
 
   // Sync horizontal scrollbar with canvas scrollX
   useEffect(() => {

--- a/src/components/canvas/GanttCanvas.tsx
+++ b/src/components/canvas/GanttCanvas.tsx
@@ -7,6 +7,7 @@ import { createDefaultTaskTime, Task } from '@/types/task';
 import { ContextMenu } from './ContextMenu';
 import { getLocalizedMonths } from '@/i18n/dateFormat';
 import { useGanttZoom } from '@/hooks/useGanttZoom';
+import { useZoomShortcuts } from '@/hooks/useZoomShortcuts';
 
 const ROW_HEIGHT = 28;
 const HEADER_HEIGHT = 50;
@@ -75,8 +76,8 @@ export function GanttCanvas() {
   const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
   const cpmResult = useAppStore(s => s.cpmResult);
 
-  // will be used by Task 8
-  const { zoomAt: _zoomAt } = useGanttZoom({ containerRef, taskTableWidth: TASK_TABLE_WIDTH });
+  const { zoomAt } = useGanttZoom({ containerRef, taskTableWidth: TASK_TABLE_WIDTH });
+  useZoomShortcuts({ zoomAt, containerRef, taskTableWidth: TASK_TABLE_WIDTH });
 
   const rendererRef = useRef<GanttRenderer | null>(null);
   const [dragState, setDragState] = useState<DragState | null>(null);

--- a/src/components/canvas/GanttCanvas.tsx
+++ b/src/components/canvas/GanttCanvas.tsx
@@ -6,6 +6,7 @@ import { diffDays, formatDate, parseDate, addCalendarDays, diffCalendarDays } fr
 import { createDefaultTaskTime, Task } from '@/types/task';
 import { ContextMenu } from './ContextMenu';
 import { getLocalizedMonths } from '@/i18n/dateFormat';
+import { useGanttZoom } from '@/hooks/useGanttZoom';
 
 const ROW_HEIGHT = 28;
 const HEADER_HEIGHT = 50;
@@ -73,6 +74,9 @@ export function GanttCanvas() {
   const weekStartDay = useAppStore(s => s.ui.weekStartDay);
   const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
   const cpmResult = useAppStore(s => s.cpmResult);
+
+  // will be used by Task 8
+  const { zoomAt: _zoomAt } = useGanttZoom({ containerRef, taskTableWidth: TASK_TABLE_WIDTH });
 
   const rendererRef = useRef<GanttRenderer | null>(null);
   const [dragState, setDragState] = useState<DragState | null>(null);

--- a/src/components/canvas/GanttCanvas.tsx
+++ b/src/components/canvas/GanttCanvas.tsx
@@ -181,15 +181,15 @@ export function GanttCanvas() {
     return () => observer.disconnect();
   }, [render]);
 
-  // Sync horizontal scrollbar with canvas scrollX
+  // Sync horizontal scrollbar with canvas scrollX (also re-sync after zoom changes)
   useEffect(() => {
     const hScroll = hScrollRef.current;
     if (!hScroll) return;
-    const scrollLeft = view.scrollX;
-    if (Math.abs(hScroll.scrollLeft - scrollLeft) > 1) {
-      hScroll.scrollLeft = scrollLeft;
+    const desired = view.scrollX;
+    if (Math.abs(hScroll.scrollLeft - desired) > 1) {
+      hScroll.scrollLeft = desired;
     }
-  }, [view.scrollX]);
+  }, [view.scrollX, view.zoom]);
 
   const defaultTaskName = tTask('defaultTask');
   const defaultMilestoneName = tTask('defaultMilestone');

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '@/state/appStore';
 import { useTranslation } from 'react-i18next';
 import { Locale, LANGUAGE_LABELS, supportedLanguages } from '@/i18n/config';
 import { UITheme, UI_THEMES } from '@/state/slices/types';
-import { saveLocale, saveTheme } from '@/utils/settingsStore';
+import { saveLocale, saveTheme, saveZoomSettings } from '@/utils/settingsStore';
 import './SettingsDialog.css';
 
 type SettingsTab = 'general' | 'language' | 'timeline';
@@ -178,7 +178,11 @@ export function SettingsDialog() {
                     <select
                       className="settings-select"
                       value={mouseWheelMode}
-                      onChange={e => setUI({ mouseWheelMode: e.target.value as 'zoom' | 'scroll' })}
+                      onChange={e => {
+                        const value = e.target.value as 'zoom' | 'scroll';
+                        setUI({ mouseWheelMode: value });
+                        void saveZoomSettings({ mouseWheelMode: value });
+                      }}
                     >
                       <option value="zoom">{t('settings.mouseWheelModeZoom')}</option>
                       <option value="scroll">{t('settings.mouseWheelModeScroll')}</option>
@@ -189,7 +193,11 @@ export function SettingsDialog() {
                     <select
                       className="settings-select"
                       value={weekStartDay}
-                      onChange={e => setUI({ weekStartDay: e.target.value as 'monday' | 'sunday' })}
+                      onChange={e => {
+                        const value = e.target.value as 'monday' | 'sunday';
+                        setUI({ weekStartDay: value });
+                        void saveZoomSettings({ weekStartDay: value });
+                      }}
                     >
                       <option value="monday">{t('settings.weekStartMonday')}</option>
                       <option value="sunday">{t('settings.weekStartSunday')}</option>
@@ -200,7 +208,11 @@ export function SettingsDialog() {
                       <input
                         type="checkbox"
                         checked={enableQuarterHourZoom}
-                        onChange={e => setUI({ enableQuarterHourZoom: e.target.checked })}
+                        onChange={e => {
+                          const checked = e.target.checked;
+                          setUI({ enableQuarterHourZoom: checked });
+                          void saveZoomSettings({ enableQuarterHourZoom: checked });
+                        }}
                       />
                       <span>{t('settings.enableQuarterHourZoom')}</span>
                     </label>
@@ -210,7 +222,11 @@ export function SettingsDialog() {
                       <input
                         type="checkbox"
                         checked={smoothZoom}
-                        onChange={e => setUI({ smoothZoom: e.target.checked })}
+                        onChange={e => {
+                          const checked = e.target.checked;
+                          setUI({ smoothZoom: checked });
+                          void saveZoomSettings({ smoothZoom: checked });
+                        }}
                       />
                       <span>{t('settings.smoothZoom')}</span>
                     </label>

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -6,13 +6,17 @@ import { UITheme, UI_THEMES } from '@/state/slices/types';
 import { saveLocale, saveTheme } from '@/utils/settingsStore';
 import './SettingsDialog.css';
 
-type SettingsTab = 'general' | 'language';
+type SettingsTab = 'general' | 'language' | 'timeline';
 
 
 export function SettingsDialog() {
   const { t, i18n } = useTranslation('common');
   const setUI = useAppStore(s => s.setUI);
   const currentTheme = useAppStore(s => s.ui.uiTheme);
+  const mouseWheelMode = useAppStore(s => s.ui.mouseWheelMode);
+  const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
+  const weekStartDay = useAppStore(s => s.ui.weekStartDay);
+  const smoothZoom = useAppStore(s => s.ui.smoothZoom);
 
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
   const [pendingLocale, setPendingLocale] = useState<Locale>(i18n.language as Locale);
@@ -96,6 +100,12 @@ export function SettingsDialog() {
               >
                 {t('settings.language')}
               </button>
+              <button
+                className={`settings-tab ${activeTab === 'timeline' ? 'active' : ''}`}
+                onClick={() => setActiveTab('timeline')}
+              >
+                {t('settings.timeline')}
+              </button>
             </div>
 
             {/* Right content */}
@@ -157,6 +167,53 @@ export function SettingsDialog() {
                           );
                         })}
                     </select>
+                  </div>
+                </div>
+              )}
+
+              {activeTab === 'timeline' && (
+                <div className="settings-section-list">
+                  <div className="settings-section">
+                    <h3>{t('settings.mouseWheelMode')}</h3>
+                    <select
+                      className="settings-select"
+                      value={mouseWheelMode}
+                      onChange={e => setUI({ mouseWheelMode: e.target.value as 'zoom' | 'scroll' })}
+                    >
+                      <option value="zoom">{t('settings.mouseWheelModeZoom')}</option>
+                      <option value="scroll">{t('settings.mouseWheelModeScroll')}</option>
+                    </select>
+                  </div>
+                  <div className="settings-section">
+                    <h3>{t('settings.weekStartDay')}</h3>
+                    <select
+                      className="settings-select"
+                      value={weekStartDay}
+                      onChange={e => setUI({ weekStartDay: e.target.value as 'monday' | 'sunday' })}
+                    >
+                      <option value="monday">{t('settings.weekStartMonday')}</option>
+                      <option value="sunday">{t('settings.weekStartSunday')}</option>
+                    </select>
+                  </div>
+                  <div className="settings-section">
+                    <label className="settings-row" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                      <input
+                        type="checkbox"
+                        checked={enableQuarterHourZoom}
+                        onChange={e => setUI({ enableQuarterHourZoom: e.target.checked })}
+                      />
+                      <span>{t('settings.enableQuarterHourZoom')}</span>
+                    </label>
+                  </div>
+                  <div className="settings-section">
+                    <label className="settings-row" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                      <input
+                        type="checkbox"
+                        checked={smoothZoom}
+                        onChange={e => setUI({ smoothZoom: e.target.checked })}
+                      />
+                      <span>{t('settings.smoothZoom')}</span>
+                    </label>
                   </div>
                 </div>
               )}

--- a/src/components/dialogs/SettingsDialog.tsx
+++ b/src/components/dialogs/SettingsDialog.tsx
@@ -13,10 +13,8 @@ export function SettingsDialog() {
   const { t, i18n } = useTranslation('common');
   const setUI = useAppStore(s => s.setUI);
   const currentTheme = useAppStore(s => s.ui.uiTheme);
-  const mouseWheelMode = useAppStore(s => s.ui.mouseWheelMode);
   const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
   const weekStartDay = useAppStore(s => s.ui.weekStartDay);
-  const smoothZoom = useAppStore(s => s.ui.smoothZoom);
 
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
   const [pendingLocale, setPendingLocale] = useState<Locale>(i18n.language as Locale);
@@ -174,21 +172,6 @@ export function SettingsDialog() {
               {activeTab === 'timeline' && (
                 <div className="settings-section-list">
                   <div className="settings-section">
-                    <h3>{t('settings.mouseWheelMode')}</h3>
-                    <select
-                      className="settings-select"
-                      value={mouseWheelMode}
-                      onChange={e => {
-                        const value = e.target.value as 'zoom' | 'scroll';
-                        setUI({ mouseWheelMode: value });
-                        void saveZoomSettings({ mouseWheelMode: value });
-                      }}
-                    >
-                      <option value="zoom">{t('settings.mouseWheelModeZoom')}</option>
-                      <option value="scroll">{t('settings.mouseWheelModeScroll')}</option>
-                    </select>
-                  </div>
-                  <div className="settings-section">
                     <h3>{t('settings.weekStartDay')}</h3>
                     <select
                       className="settings-select"
@@ -215,20 +198,6 @@ export function SettingsDialog() {
                         }}
                       />
                       <span>{t('settings.enableQuarterHourZoom')}</span>
-                    </label>
-                  </div>
-                  <div className="settings-section">
-                    <label className="settings-row" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                      <input
-                        type="checkbox"
-                        checked={smoothZoom}
-                        onChange={e => {
-                          const checked = e.target.checked;
-                          setUI({ smoothZoom: checked });
-                          void saveZoomSettings({ smoothZoom: checked });
-                        }}
-                      />
-                      <span>{t('settings.smoothZoom')}</span>
                     </label>
                   </div>
                 </div>

--- a/src/components/dialogs/TaskDialog.tsx
+++ b/src/components/dialogs/TaskDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useAppStore } from '@/state/appStore';
 import { useTranslation } from 'react-i18next';
 import { TaskType } from '@/types/task';
@@ -28,8 +28,11 @@ export function TaskDialog() {
   const [duration, setDuration] = useState(5);
   const [startDate, setStartDate] = useState('');
   const [parentId, setParentId] = useState<string>('');
+  const nameInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
+    if (!showTaskDialog) return;
+
     if (editingTask) {
       setName(editingTask.name);
       setDescription(editingTask.description);
@@ -49,7 +52,19 @@ export function TaskDialog() {
       setStartDate(project.startDate);
       setParentId('');
     }
-  }, [editingTask, project.startDate]);
+
+  }, [showTaskDialog, editingTaskId, editingTask, project.startDate]);
+
+  useEffect(() => {
+    if (!showTaskDialog) return;
+    const id = setTimeout(() => {
+      const el = nameInputRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(0, el.value.length);
+    }, 30);
+    return () => clearTimeout(id);
+  }, [showTaskDialog, editingTaskId]);
 
   if (!showTaskDialog) return null;
 
@@ -120,10 +135,10 @@ export function TaskDialog() {
           <div className="flex flex-col gap-1">
             <label className="text-text-secondary">{t('dialog.nameRequired')}</label>
             <input
+              ref={nameInputRef}
               value={name}
               onChange={e => setName(e.target.value)}
               className="px-2 py-1.5 bg-surface border border-border rounded focus:border-accent focus:outline-none"
-              autoFocus
             />
           </div>
 

--- a/src/engine/renderer/GanttRenderer.ts
+++ b/src/engine/renderer/GanttRenderer.ts
@@ -118,10 +118,11 @@ export class GanttRenderer {
     return result;
   }
 
-  /** Convert a date to X position on canvas */
+  /** Convert a date (with optional sub-day precision) to X position on canvas */
   dateToX(date: Date): number {
-    const daysDiff = diffCalendarDays(this.viewStart, date);
-    return this.opts.taskTableWidth + daysDiff * this.opts.view.zoom - this.opts.view.scrollX;
+    const msPerDay = 86400000;
+    const daysFromStart = (date.getTime() - this.viewStart.getTime()) / msPerDay;
+    return this.opts.taskTableWidth + daysFromStart * this.opts.view.zoom - this.opts.view.scrollX;
   }
 
   /** Convert task row index to Y position */
@@ -206,7 +207,7 @@ export class GanttRenderer {
   }
 
   private drawTimelineHeader(): void {
-    const { canvasWidth, headerHeight, taskTableWidth, view, weekStartDay, enableQuarterHourZoom, localizedMonths } = this.opts;
+    const { canvasWidth, headerHeight, view, enableQuarterHourZoom } = this.opts;
     const ctx = this.ctx;
 
     // Header background + bottom border
@@ -219,7 +220,6 @@ export class GanttRenderer {
     ctx.lineTo(canvasWidth, headerHeight);
     ctx.stroke();
 
-    const wsd = weekStartDay ?? 'monday';
     const enableQH = enableQuarterHourZoom ?? false;
     const { major, minor } = pickTiers(view.zoom, enableQH);
 
@@ -232,36 +232,34 @@ export class GanttRenderer {
     ctx.fillStyle = this.colors.text;
     ctx.textBaseline = 'middle';
     ctx.textAlign = 'left';
-    this.drawTierLabels(major, startDate, endDate, taskTableWidth, headerHeight / 4, wsd, localizedMonths);
+    this.drawTierLabels(major, startDate, endDate, headerHeight / 4);
 
     // --- Bottom row: minor tier ---
     ctx.font = '10px -apple-system, BlinkMacSystemFont, sans-serif';
     ctx.fillStyle = this.colors.textSecondary;
-    this.drawTierLabels(minor, startDate, endDate, taskTableWidth, headerHeight * 3 / 4, wsd, localizedMonths);
+    this.drawTierLabels(minor, startDate, endDate, headerHeight * 3 / 4);
   }
 
   private drawTierLabels(
     tier: TimelineTier,
     startDate: Date,
     endDate: Date,
-    taskTableWidth: number,
     yCenter: number,
-    weekStartDay: 'monday' | 'sunday',
-    localizedMonths?: string[]
   ): void {
-    const { canvasWidth } = this.opts;
+    const { canvasWidth, taskTableWidth, weekStartDay, localizedMonths } = this.opts;
+    const wsd = weekStartDay ?? 'monday';
     const ctx = this.ctx;
     const cfg = TIER_CONFIG[tier];
 
     // Snap to the tick boundary at-or-before startDate
-    let cursor = snapToTickStart(startDate, tier, weekStartDay);
+    let cursor = snapToTickStart(startDate, tier, wsd);
     let lastDrawnRight = -Infinity;
 
     while (cursor.getTime() <= endDate.getTime()) {
       const next = nextTickBoundary(cursor, tier);
-      const x1 = this.dateToXMs(cursor);
-      const x2 = this.dateToXMs(next);
-      const labelText = this.formatTierLabel(tier, cursor, weekStartDay, localizedMonths);
+      const x1 = this.dateToX(cursor);
+      const x2 = this.dateToX(next);
+      const labelText = this.formatTierLabel(tier, cursor, wsd, localizedMonths);
 
       // Skip tick entirely if it doesn't reach the visible task area
       if (x2 <= taskTableWidth) {
@@ -302,13 +300,6 @@ export class GanttRenderer {
       case 'hour':        return `${pad(d.getUTCHours())}:00`;
       case 'quarterHour': return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
     }
-  }
-
-  /** Convert a Date (with possible sub-day precision) to canvas X. */
-  private dateToXMs(date: Date): number {
-    const msPerDay = 86400000;
-    const daysFromStart = (date.getTime() - this.viewStart.getTime()) / msPerDay;
-    return this.opts.taskTableWidth + daysFromStart * this.opts.view.zoom - this.opts.view.scrollX;
   }
 
   private drawTaskBars(): void {

--- a/src/engine/renderer/GanttRenderer.ts
+++ b/src/engine/renderer/GanttRenderer.ts
@@ -1,8 +1,9 @@
 import { Task } from '@/types/task';
 import { Sequence } from '@/types/sequence';
 import { ViewState } from '@/state/slices/types';
-import { parseDate, formatDate, addCalendarDays, getWeekNumber, diffCalendarDays, isoDayOfWeek } from '@/utils/dateUtils';
+import { parseDate, formatDate, addCalendarDays, diffCalendarDays, isoDayOfWeek, getWeekNumberFor } from '@/utils/dateUtils';
 import { WorkCalendar } from '@/types/calendar';
+import { TimelineTier, TIER_CONFIG, pickTiers, nextTickBoundary, snapToTickStart } from './timelineTiers';
 
 export interface GanttRenderOptions {
   tasks: Task[];
@@ -18,6 +19,8 @@ export interface GanttRenderOptions {
   headerHeight: number;
   localizedMonths?: string[];
   columnHeaders?: { wbs: string; taskName: string; duration: string };
+  weekStartDay?: 'monday' | 'sunday';        // default 'monday'
+  enableQuarterHourZoom?: boolean;            // default false
 }
 
 // Read theme colors from CSS variables on the document element
@@ -165,7 +168,7 @@ export class GanttRenderer {
 
       // Vertical grid line
       ctx.strokeStyle = this.colors.grid;
-      ctx.lineWidth = dayOfWeek === 1 ? 1 : 0.5; // Thicker on Monday
+      ctx.lineWidth = dayOfWeek === (this.opts.weekStartDay === 'sunday' ? 7 : 1) ? 1 : 0.5;
       ctx.beginPath();
       ctx.moveTo(x, headerHeight);
       ctx.lineTo(x, canvasHeight);
@@ -203,14 +206,12 @@ export class GanttRenderer {
   }
 
   private drawTimelineHeader(): void {
-    const { canvasWidth, headerHeight, taskTableWidth, view } = this.opts;
+    const { canvasWidth, headerHeight, taskTableWidth, view, weekStartDay, enableQuarterHourZoom, localizedMonths } = this.opts;
     const ctx = this.ctx;
 
-    // Header background
+    // Header background + bottom border
     ctx.fillStyle = this.colors.headerBg;
     ctx.fillRect(0, 0, canvasWidth, headerHeight);
-
-    // Bottom border
     ctx.strokeStyle = this.colors.border;
     ctx.lineWidth = 1;
     ctx.beginPath();
@@ -218,53 +219,96 @@ export class GanttRenderer {
     ctx.lineTo(canvasWidth, headerHeight);
     ctx.stroke();
 
-    const visibleDays = Math.ceil(canvasWidth / view.zoom) + 2;
-    const startOffset = Math.floor(view.scrollX / view.zoom);
+    const wsd = weekStartDay ?? 'monday';
+    const enableQH = enableQuarterHourZoom ?? false;
+    const { major, minor } = pickTiers(view.zoom, enableQH);
 
-    // Draw month/week labels (top row)
-    ctx.font = '11px -apple-system, BlinkMacSystemFont, sans-serif';
+    // Visible date range
+    const startDate = addCalendarDays(this.viewStart, Math.floor(view.scrollX / view.zoom) - 1);
+    const endDate = addCalendarDays(this.viewStart, Math.ceil((view.scrollX + canvasWidth) / view.zoom) + 1);
+
+    // --- Top row: major tier ---
+    ctx.font = 'bold 11px -apple-system, BlinkMacSystemFont, sans-serif';
     ctx.fillStyle = this.colors.text;
     ctx.textBaseline = 'middle';
+    ctx.textAlign = 'left';
+    this.drawTierLabels(major, startDate, endDate, taskTableWidth, headerHeight / 4, wsd, localizedMonths);
 
-    let lastMonth = -1;
-    let lastWeek = -1;
+    // --- Bottom row: minor tier ---
+    ctx.font = '10px -apple-system, BlinkMacSystemFont, sans-serif';
+    ctx.fillStyle = this.colors.textSecondary;
+    this.drawTierLabels(minor, startDate, endDate, taskTableWidth, headerHeight * 3 / 4, wsd, localizedMonths);
+  }
 
-    for (let i = -1; i < visibleDays; i++) {
-      const date = addCalendarDays(this.viewStart, startOffset + i);
-      const x = this.dateToX(date);
+  private drawTierLabels(
+    tier: TimelineTier,
+    startDate: Date,
+    endDate: Date,
+    taskTableWidth: number,
+    yCenter: number,
+    weekStartDay: 'monday' | 'sunday',
+    localizedMonths?: string[]
+  ): void {
+    const { canvasWidth } = this.opts;
+    const ctx = this.ctx;
+    const cfg = TIER_CONFIG[tier];
 
-      if (x < taskTableWidth) continue;
+    // Snap to the tick boundary at-or-before startDate
+    let cursor = snapToTickStart(startDate, tier, weekStartDay);
+    let lastDrawnRight = -Infinity;
 
-      const month = date.getUTCMonth();
-      const weekNum = getWeekNumber(date);
-      const dayOfWeek = isoDayOfWeek(date);
+    while (cursor.getTime() <= endDate.getTime()) {
+      const next = nextTickBoundary(cursor, tier);
+      const x1 = this.dateToXMs(cursor);
+      const x2 = this.dateToXMs(next);
+      const labelText = this.formatTierLabel(tier, cursor, weekStartDay, localizedMonths);
 
-      // Month label (top row)
-      if (month !== lastMonth) {
-        lastMonth = month;
-        const months = this.opts.localizedMonths || ['Januari', 'Februari', 'Maart', 'April', 'Mei', 'Juni', 'Juli', 'Augustus', 'September', 'Oktober', 'November', 'December'];
-        ctx.fillStyle = this.colors.text;
-        ctx.font = 'bold 11px -apple-system, BlinkMacSystemFont, sans-serif';
-        ctx.fillText(`${months[month]} ${date.getUTCFullYear()}`, x + 4, headerHeight / 4);
+      // Skip tick entirely if it doesn't reach the visible task area
+      if (x2 <= taskTableWidth) {
+        cursor = next;
+        continue;
+      }
+      // Stop once we're past the right edge
+      if (x1 >= canvasWidth) break;
+
+      const labelX = Math.max(x1 + 4, taskTableWidth + 4);
+      const slotWidth = x2 - Math.max(x1, taskTableWidth);
+
+      // Defensive skip: if slot is too narrow OR we'd overlap the previous label
+      if (slotWidth >= cfg.minLabelWidth && labelX > lastDrawnRight + 4) {
+        ctx.fillText(labelText, labelX, yCenter);
+        const measured = ctx.measureText(labelText).width;
+        lastDrawnRight = labelX + measured;
       }
 
-      // Week label (bottom row)
-      if (dayOfWeek === 1 && weekNum !== lastWeek) {
-        lastWeek = weekNum;
-        ctx.fillStyle = this.colors.textSecondary;
-        ctx.font = '10px -apple-system, BlinkMacSystemFont, sans-serif';
-        ctx.fillText(`W${weekNum}`, x + 2, headerHeight * 3 / 4);
-      }
-
-      // Day number if zoom is large enough
-      if (view.zoom >= 20) {
-        ctx.fillStyle = this.colors.textSecondary;
-        ctx.font = '9px -apple-system, BlinkMacSystemFont, sans-serif';
-        ctx.textAlign = 'center';
-        ctx.fillText(`${date.getUTCDate()}`, x + view.zoom / 2, headerHeight / 2);
-        ctx.textAlign = 'left';
-      }
+      cursor = next;
     }
+  }
+
+  private formatTierLabel(
+    tier: TimelineTier,
+    d: Date,
+    weekStartDay: 'monday' | 'sunday',
+    localizedMonths?: string[]
+  ): string {
+    const months = localizedMonths || ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    switch (tier) {
+      case 'year':        return `${d.getUTCFullYear()}`;
+      case 'quarter':     return `Q${Math.floor(d.getUTCMonth() / 3) + 1} ${d.getUTCFullYear()}`;
+      case 'month':       return `${months[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+      case 'week':        return `W${getWeekNumberFor(d, weekStartDay)}`;
+      case 'day':         return `${d.getUTCDate()}`;
+      case 'hour':        return `${pad(d.getUTCHours())}:00`;
+      case 'quarterHour': return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+    }
+  }
+
+  /** Convert a Date (with possible sub-day precision) to canvas X. */
+  private dateToXMs(date: Date): number {
+    const msPerDay = 86400000;
+    const daysFromStart = (date.getTime() - this.viewStart.getTime()) / msPerDay;
+    return this.opts.taskTableWidth + daysFromStart * this.opts.view.zoom - this.opts.view.scrollX;
   }
 
   private drawTaskBars(): void {

--- a/src/engine/renderer/timelineTiers.ts
+++ b/src/engine/renderer/timelineTiers.ts
@@ -1,0 +1,122 @@
+import { addCalendarDays } from '@/utils/dateUtils';
+
+export type TimelineTier =
+  | 'year'
+  | 'quarter'
+  | 'month'
+  | 'week'
+  | 'day'
+  | 'hour'
+  | 'quarterHour';
+
+export interface TierConfig {
+  tier: TimelineTier;
+  /** Minimum pixel width a label of this tier needs to be readable. Used as a defensive skip-rule. */
+  minLabelWidth: number;
+  /**
+   * Step from one tick to the next, in fractional days.
+   * For tiers larger than a day this is approximate (months/years vary); the renderer
+   * uses the date-based "next boundary" function instead. For sub-day tiers it's exact.
+   */
+  stepDays: number;
+}
+
+export const TIER_CONFIG: Record<TimelineTier, TierConfig> = {
+  year:        { tier: 'year',        minLabelWidth: 60, stepDays: 365 },
+  quarter:     { tier: 'quarter',     minLabelWidth: 40, stepDays: 90 },
+  month:       { tier: 'month',       minLabelWidth: 50, stepDays: 30 },
+  week:        { tier: 'week',        minLabelWidth: 28, stepDays: 7 },
+  day:         { tier: 'day',         minLabelWidth: 18, stepDays: 1 },
+  hour:        { tier: 'hour',        minLabelWidth: 28, stepDays: 1 / 24 },
+  quarterHour: { tier: 'quarterHour', minLabelWidth: 28, stepDays: 1 / 96 },
+};
+
+/**
+ * Pick the {major, minor} tier pair for the given zoom (pixels per day).
+ * QH-tier is only used when enableQuarterHour is true.
+ */
+export function pickTiers(
+  zoom: number,
+  enableQuarterHour: boolean
+): { major: TimelineTier; minor: TimelineTier } {
+  if (zoom < 4) return { major: 'year', minor: 'quarter' };
+  if (zoom < 10) return { major: 'year', minor: 'month' };
+  if (zoom < 25) return { major: 'month', minor: 'week' };
+  if (zoom < 80) return { major: 'month', minor: 'day' };
+  if (zoom < 400 || !enableQuarterHour) return { major: 'day', minor: 'hour' };
+  return { major: 'hour', minor: 'quarterHour' };
+}
+
+/**
+ * Given a starting date and a tier, return the date of the next tick boundary
+ * (e.g. for 'month', the first of next month). For sub-day tiers, returns
+ * `from + stepDays`.
+ */
+export function nextTickBoundary(from: Date, tier: TimelineTier): Date {
+  switch (tier) {
+    case 'year':
+      return new Date(Date.UTC(from.getUTCFullYear() + 1, 0, 1));
+    case 'quarter': {
+      const m = from.getUTCMonth();
+      const nextQ = Math.floor(m / 3) * 3 + 3;
+      if (nextQ >= 12) return new Date(Date.UTC(from.getUTCFullYear() + 1, 0, 1));
+      return new Date(Date.UTC(from.getUTCFullYear(), nextQ, 1));
+    }
+    case 'month': {
+      const m = from.getUTCMonth();
+      if (m === 11) return new Date(Date.UTC(from.getUTCFullYear() + 1, 0, 1));
+      return new Date(Date.UTC(from.getUTCFullYear(), m + 1, 1));
+    }
+    case 'week':
+      return addCalendarDays(from, 7);
+    case 'day':
+      return addCalendarDays(from, 1);
+    case 'hour': {
+      const r = new Date(from.getTime());
+      r.setUTCHours(r.getUTCHours() + 1, 0, 0, 0);
+      return r;
+    }
+    case 'quarterHour': {
+      const r = new Date(from.getTime());
+      r.setUTCMinutes(r.getUTCMinutes() + 15, 0, 0);
+      return r;
+    }
+  }
+}
+
+/** Snap a date back to the start of its current tick (e.g. start of month). */
+export function snapToTickStart(date: Date, tier: TimelineTier, weekStartDay: 'monday' | 'sunday' = 'monday'): Date {
+  switch (tier) {
+    case 'year':
+      return new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+    case 'quarter': {
+      const m = date.getUTCMonth();
+      return new Date(Date.UTC(date.getUTCFullYear(), Math.floor(m / 3) * 3, 1));
+    }
+    case 'month':
+      return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+    case 'week': {
+      const r = new Date(date.getTime());
+      const dow = r.getUTCDay();           // 0=Sun..6=Sat
+      const offset = weekStartDay === 'sunday' ? dow : (dow === 0 ? 6 : dow - 1);
+      r.setUTCDate(r.getUTCDate() - offset);
+      r.setUTCHours(0, 0, 0, 0);
+      return r;
+    }
+    case 'day': {
+      const r = new Date(date.getTime());
+      r.setUTCHours(0, 0, 0, 0);
+      return r;
+    }
+    case 'hour': {
+      const r = new Date(date.getTime());
+      r.setUTCMinutes(0, 0, 0);
+      return r;
+    }
+    case 'quarterHour': {
+      const r = new Date(date.getTime());
+      r.setUTCMinutes(Math.floor(r.getUTCMinutes() / 15) * 15, 0, 0);
+      return r;
+    }
+  }
+}

--- a/src/hooks/useGanttZoom.ts
+++ b/src/hooks/useGanttZoom.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from 'react';
+import { useAppStore } from '@/state/appStore';
+
+interface UseGanttZoomOpts {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  taskTableWidth: number;
+}
+
+const ZOOM_FACTOR_PER_TICK = 1.1;
+const ANIM_DURATION_MS = 180;
+
+export function useGanttZoom({ containerRef, taskTableWidth }: UseGanttZoomOpts) {
+  const view = useAppStore(s => s.view);
+  const setZoom = useAppStore(s => s.setZoom);
+  const setScroll = useAppStore(s => s.setScroll);
+  const mouseWheelMode = useAppStore(s => s.ui.mouseWheelMode);
+  const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
+  const smoothZoom = useAppStore(s => s.ui.smoothZoom);
+
+  // Latest values in a ref so the wheel handler doesn't re-attach every render
+  const latest = useRef({ view, mouseWheelMode, enableQuarterHourZoom, smoothZoom });
+  latest.current = { view, mouseWheelMode, enableQuarterHourZoom, smoothZoom };
+
+  const animRef = useRef<number | null>(null);
+
+  // Cursor-anchored zoom step. anchorX is canvas-X (pixels from canvas left edge).
+  const zoomAt = (newZoom: number, anchorX: number) => {
+    const { view: v, enableQuarterHourZoom: enableQH } = latest.current;
+    const max = enableQH ? 1000 : 400;
+    const clamped = Math.max(0.5, Math.min(max, newZoom));
+    if (clamped === v.zoom) return;
+
+    // Date under the cursor at current zoom (in fractional days from viewStart)
+    const localX = anchorX - taskTableWidth + v.scrollX;
+    const daysUnderCursor = localX / v.zoom;
+
+    // New scrollX so the same fractional day stays under the cursor
+    const newScrollX = Math.max(0, daysUnderCursor * clamped - (anchorX - taskTableWidth));
+
+    if (latest.current.smoothZoom) {
+      animateTo(clamped, newScrollX);
+    } else {
+      setZoom(clamped);
+      setScroll(newScrollX, v.scrollY);
+    }
+  };
+
+  const animateTo = (targetZoom: number, targetScrollX: number) => {
+    if (animRef.current !== null) cancelAnimationFrame(animRef.current);
+    const startZoom = latest.current.view.zoom;
+    const startScrollX = latest.current.view.scrollX;
+    const startTime = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - startTime) / ANIM_DURATION_MS);
+      const eased = 1 - Math.pow(1 - t, 3); // ease-out-cubic
+      const z = startZoom + (targetZoom - startZoom) * eased;
+      const x = startScrollX + (targetScrollX - startScrollX) * eased;
+      setZoom(z);
+      setScroll(x, latest.current.view.scrollY);
+      if (t < 1) animRef.current = requestAnimationFrame(tick);
+      else animRef.current = null;
+    };
+    animRef.current = requestAnimationFrame(tick);
+  };
+
+  // Wheel handler
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = container.getBoundingClientRect();
+      const anchorX = e.clientX - rect.left;
+      const { mouseWheelMode: mode, view: v } = latest.current;
+
+      const isZoomGesture =
+        e.ctrlKey || e.metaKey ||
+        (mode === 'zoom' && !e.shiftKey);
+
+      if (isZoomGesture) {
+        const factor = e.deltaY > 0 ? 1 / ZOOM_FACTOR_PER_TICK : ZOOM_FACTOR_PER_TICK;
+        zoomAt(v.zoom * factor, anchorX);
+        return;
+      }
+
+      // Scroll path
+      if (mode === 'zoom' && e.shiftKey) {
+        // Shift+wheel scrolls horizontally
+        setScroll(v.scrollX + e.deltaY, v.scrollY);
+      } else if (mode === 'scroll') {
+        if (e.shiftKey) {
+          setScroll(v.scrollX + e.deltaY, v.scrollY);
+        } else {
+          setScroll(v.scrollX + e.deltaX, v.scrollY + e.deltaY);
+        }
+      }
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+      if (animRef.current !== null) cancelAnimationFrame(animRef.current);
+    };
+  }, [containerRef, taskTableWidth, setZoom, setScroll]);
+
+  return { zoomAt };
+}

--- a/src/hooks/useGanttZoom.ts
+++ b/src/hooks/useGanttZoom.ts
@@ -7,21 +7,16 @@ interface UseGanttZoomOpts {
 }
 
 const ZOOM_FACTOR_PER_TICK = 1.1;
-const ANIM_DURATION_MS = 180;
 
 export function useGanttZoom({ containerRef, taskTableWidth }: UseGanttZoomOpts) {
   const view = useAppStore(s => s.view);
   const setZoom = useAppStore(s => s.setZoom);
   const setScroll = useAppStore(s => s.setScroll);
-  const mouseWheelMode = useAppStore(s => s.ui.mouseWheelMode);
   const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
-  const smoothZoom = useAppStore(s => s.ui.smoothZoom);
 
   // Latest values in a ref so the wheel handler doesn't re-attach every render
-  const latest = useRef({ view, mouseWheelMode, enableQuarterHourZoom, smoothZoom });
-  latest.current = { view, mouseWheelMode, enableQuarterHourZoom, smoothZoom };
-
-  const animRef = useRef<number | null>(null);
+  const latest = useRef({ view, enableQuarterHourZoom });
+  latest.current = { view, enableQuarterHourZoom };
 
   // Cursor-anchored zoom step. anchorX is canvas-X (pixels from canvas left edge).
   const zoomAt = (newZoom: number, anchorX: number) => {
@@ -37,30 +32,8 @@ export function useGanttZoom({ containerRef, taskTableWidth }: UseGanttZoomOpts)
     // New scrollX so the same fractional day stays under the cursor
     const newScrollX = Math.max(0, daysUnderCursor * clamped - (anchorX - taskTableWidth));
 
-    if (latest.current.smoothZoom) {
-      animateTo(clamped, newScrollX);
-    } else {
-      setZoom(clamped);
-      setScroll(newScrollX, v.scrollY);
-    }
-  };
-
-  const animateTo = (targetZoom: number, targetScrollX: number) => {
-    if (animRef.current !== null) cancelAnimationFrame(animRef.current);
-    const startZoom = latest.current.view.zoom;
-    const startScrollX = latest.current.view.scrollX;
-    const startTime = performance.now();
-    const tick = (now: number) => {
-      const t = Math.min(1, (now - startTime) / ANIM_DURATION_MS);
-      const eased = 1 - Math.pow(1 - t, 3); // ease-out-cubic
-      const z = startZoom + (targetZoom - startZoom) * eased;
-      const x = startScrollX + (targetScrollX - startScrollX) * eased;
-      setZoom(z);
-      setScroll(x, latest.current.view.scrollY);
-      if (t < 1) animRef.current = requestAnimationFrame(tick);
-      else animRef.current = null;
-    };
-    animRef.current = requestAnimationFrame(tick);
+    setZoom(clamped);
+    setScroll(newScrollX, v.scrollY);
   };
 
   // Wheel handler
@@ -72,35 +45,24 @@ export function useGanttZoom({ containerRef, taskTableWidth }: UseGanttZoomOpts)
       e.preventDefault();
       const rect = container.getBoundingClientRect();
       const anchorX = e.clientX - rect.left;
-      const { mouseWheelMode: mode, view: v } = latest.current;
+      const { view: v } = latest.current;
 
-      const isZoomGesture =
-        e.ctrlKey || e.metaKey ||
-        (mode === 'zoom' && !e.shiftKey);
-
-      if (isZoomGesture) {
+      if (e.ctrlKey || e.metaKey) {
         const factor = e.deltaY > 0 ? 1 / ZOOM_FACTOR_PER_TICK : ZOOM_FACTOR_PER_TICK;
         zoomAt(v.zoom * factor, anchorX);
         return;
       }
 
-      // Scroll path
-      if (mode === 'zoom' && e.shiftKey) {
-        // Shift+wheel scrolls horizontally
+      if (e.shiftKey) {
+        setScroll(v.scrollX, v.scrollY + e.deltaY);
+      } else {
         setScroll(v.scrollX + e.deltaY, v.scrollY);
-      } else if (mode === 'scroll') {
-        if (e.shiftKey) {
-          setScroll(v.scrollX + e.deltaY, v.scrollY);
-        } else {
-          setScroll(v.scrollX + e.deltaX, v.scrollY + e.deltaY);
-        }
       }
     };
 
     container.addEventListener('wheel', handleWheel, { passive: false });
     return () => {
       container.removeEventListener('wheel', handleWheel);
-      if (animRef.current !== null) cancelAnimationFrame(animRef.current);
     };
   }, [containerRef, taskTableWidth, setZoom, setScroll]);
 

--- a/src/hooks/useZoomShortcuts.ts
+++ b/src/hooks/useZoomShortcuts.ts
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import { useAppStore } from '@/state/appStore';
+import { parseDate, diffCalendarDays } from '@/utils/dateUtils';
+
+interface UseZoomShortcutsOpts {
+  zoomAt: (newZoom: number, anchorX: number) => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  taskTableWidth: number;
+}
+
+const DEFAULT_ZOOM = 30;
+
+export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZoomShortcutsOpts) {
+  const setZoom = useAppStore(s => s.setZoom);
+  const setScroll = useAppStore(s => s.setScroll);
+  const setViewStartDate = useAppStore(s => s.setViewStartDate);
+  const tasks = useAppStore(s => s.tasks);
+  const view = useAppStore(s => s.view);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // Don't intercept while typing in an input/textarea
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const centerX = rect.width / 2;
+
+      if ((e.key === '+' || e.key === '=') && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        zoomAt(view.zoom * 1.1, centerX);
+      } else if (e.key === '-' && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        zoomAt(view.zoom / 1.1, centerX);
+      } else if (e.key === '0' && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        setZoom(DEFAULT_ZOOM);
+        setScroll(0, view.scrollY);
+      } else if (e.key === '0' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        // Fit to project
+        if (tasks.length === 0) {
+          setZoom(DEFAULT_ZOOM);
+          setScroll(0, view.scrollY);
+          return;
+        }
+        let minStart: string | null = null;
+        let maxFinish: string | null = null;
+        for (const t of tasks) {
+          const s = t.time.earlyStart || t.time.scheduleStart;
+          const f = t.time.earlyFinish || t.time.scheduleFinish || s;
+          if (s && (!minStart || s < minStart)) minStart = s;
+          if (f && (!maxFinish || f > maxFinish)) maxFinish = f;
+        }
+        if (!minStart || !maxFinish) return;
+        const span = Math.max(1, diffCalendarDays(parseDate(minStart), parseDate(maxFinish)) + 1);
+        const usable = rect.width - taskTableWidth;
+        if (usable <= 0) return;
+        const newZoom = Math.max(0.5, Math.min(400, usable / span));
+        setZoom(newZoom);
+        setViewStartDate(minStart);
+        setScroll(0, view.scrollY);
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [zoomAt, containerRef, taskTableWidth, setZoom, setScroll, setViewStartDate, view.zoom, view.scrollY, tasks]);
+}

--- a/src/hooks/useZoomShortcuts.ts
+++ b/src/hooks/useZoomShortcuts.ts
@@ -44,13 +44,13 @@ export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZo
       } else if (e.key === '0' && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
         setZoom(DEFAULT_ZOOM);
-        setScroll(0, v.scrollY);
+        setScroll(0, 0);
       } else if (e.key === '0' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         // Fit to project
         if (t.length === 0) {
           setZoom(DEFAULT_ZOOM);
-          setScroll(0, v.scrollY);
+          setScroll(0, 0);
           return;
         }
         let minStart: string | null = null;
@@ -69,7 +69,7 @@ export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZo
         const newZoom = Math.max(0.5, Math.min(max, usable / span));
         setZoom(newZoom);
         setViewStartDate(minStart);
-        setScroll(0, v.scrollY);
+        setScroll(0, 0);
       }
     };
 

--- a/src/hooks/useZoomShortcuts.ts
+++ b/src/hooks/useZoomShortcuts.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAppStore } from '@/state/appStore';
 import { parseDate, diffCalendarDays } from '@/utils/dateUtils';
 
@@ -17,6 +17,10 @@ export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZo
   const tasks = useAppStore(s => s.tasks);
   const view = useAppStore(s => s.view);
 
+  // Latest values in a ref so the keydown handler doesn't re-attach on every zoom/scroll change
+  const latest = useRef({ view, tasks });
+  latest.current = { view, tasks };
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       // Don't intercept while typing in an input/textarea
@@ -28,29 +32,31 @@ export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZo
       const rect = container.getBoundingClientRect();
       const centerX = rect.width / 2;
 
+      const { view: v, tasks: t } = latest.current;
+
       if ((e.key === '+' || e.key === '=') && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
-        zoomAt(view.zoom * 1.1, centerX);
+        zoomAt(v.zoom * 1.1, centerX);
       } else if (e.key === '-' && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
-        zoomAt(view.zoom / 1.1, centerX);
+        zoomAt(v.zoom / 1.1, centerX);
       } else if (e.key === '0' && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
         setZoom(DEFAULT_ZOOM);
-        setScroll(0, view.scrollY);
+        setScroll(0, v.scrollY);
       } else if (e.key === '0' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         // Fit to project
-        if (tasks.length === 0) {
+        if (t.length === 0) {
           setZoom(DEFAULT_ZOOM);
-          setScroll(0, view.scrollY);
+          setScroll(0, v.scrollY);
           return;
         }
         let minStart: string | null = null;
         let maxFinish: string | null = null;
-        for (const t of tasks) {
-          const s = t.time.earlyStart || t.time.scheduleStart;
-          const f = t.time.earlyFinish || t.time.scheduleFinish || s;
+        for (const task of t) {
+          const s = task.time.earlyStart || task.time.scheduleStart;
+          const f = task.time.earlyFinish || task.time.scheduleFinish || s;
           if (s && (!minStart || s < minStart)) minStart = s;
           if (f && (!maxFinish || f > maxFinish)) maxFinish = f;
         }
@@ -61,11 +67,11 @@ export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZo
         const newZoom = Math.max(0.5, Math.min(400, usable / span));
         setZoom(newZoom);
         setViewStartDate(minStart);
-        setScroll(0, view.scrollY);
+        setScroll(0, v.scrollY);
       }
     };
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [zoomAt, containerRef, taskTableWidth, setZoom, setScroll, setViewStartDate, view.zoom, view.scrollY, tasks]);
+  }, [zoomAt, containerRef, taskTableWidth, setZoom, setScroll, setViewStartDate]);
 }

--- a/src/hooks/useZoomShortcuts.ts
+++ b/src/hooks/useZoomShortcuts.ts
@@ -16,10 +16,11 @@ export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZo
   const setViewStartDate = useAppStore(s => s.setViewStartDate);
   const tasks = useAppStore(s => s.tasks);
   const view = useAppStore(s => s.view);
+  const enableQuarterHourZoom = useAppStore(s => s.ui.enableQuarterHourZoom);
 
   // Latest values in a ref so the keydown handler doesn't re-attach on every zoom/scroll change
-  const latest = useRef({ view, tasks });
-  latest.current = { view, tasks };
+  const latest = useRef({ view, tasks, enableQuarterHourZoom });
+  latest.current = { view, tasks, enableQuarterHourZoom };
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -32,7 +33,7 @@ export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZo
       const rect = container.getBoundingClientRect();
       const centerX = rect.width / 2;
 
-      const { view: v, tasks: t } = latest.current;
+      const { view: v, tasks: t, enableQuarterHourZoom: enableQH } = latest.current;
 
       if ((e.key === '+' || e.key === '=') && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
@@ -64,7 +65,8 @@ export function useZoomShortcuts({ zoomAt, containerRef, taskTableWidth }: UseZo
         const span = Math.max(1, diffCalendarDays(parseDate(minStart), parseDate(maxFinish)) + 1);
         const usable = rect.width - taskTableWidth;
         if (usable <= 0) return;
-        const newZoom = Math.max(0.5, Math.min(400, usable / span));
+        const max = enableQH ? 1000 : 400;
+        const newZoom = Math.max(0.5, Math.min(max, usable / span));
         setZoom(newZoom);
         setViewStartDate(minStart);
         setScroll(0, v.scrollY);

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -36,14 +36,10 @@
     "projectInfo": "Project information...",
     "theme": "Theme",
     "timeline": "Timeline / Zoom",
-    "mouseWheelMode": "Mouse wheel behavior",
-    "mouseWheelModeZoom": "Zoom",
-    "mouseWheelModeScroll": "Scroll",
     "enableQuarterHourZoom": "Show quarter-hours when zoomed in far",
     "weekStartDay": "Week starts on",
     "weekStartMonday": "Monday",
-    "weekStartSunday": "Sunday",
-    "smoothZoom": "Smooth zoom animation"
+    "weekStartSunday": "Sunday"
   },
   "confirm": {
     "newProject": "Create new project? Unsaved changes will be lost.",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -34,7 +34,16 @@
     "version": "Version",
     "defaultZoom": "Default zoom",
     "projectInfo": "Project information...",
-    "theme": "Theme"
+    "theme": "Theme",
+    "timeline": "Timeline / Zoom",
+    "mouseWheelMode": "Mouse wheel behavior",
+    "mouseWheelModeZoom": "Zoom",
+    "mouseWheelModeScroll": "Scroll",
+    "enableQuarterHourZoom": "Show quarter-hours when zoomed in far",
+    "weekStartDay": "Week starts on",
+    "weekStartMonday": "Monday",
+    "weekStartSunday": "Sunday",
+    "smoothZoom": "Smooth zoom animation"
   },
   "confirm": {
     "newProject": "Create new project? Unsaved changes will be lost.",

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -36,14 +36,10 @@
     "projectInfo": "Projectinformatie...",
     "theme": "Thema",
     "timeline": "Tijdlijn / Zoomen",
-    "mouseWheelMode": "Muiswiel-gedrag",
-    "mouseWheelModeZoom": "Zoomen",
-    "mouseWheelModeScroll": "Scrollen",
     "enableQuarterHourZoom": "Kwartieren tonen bij ver inzoomen",
     "weekStartDay": "Week begint op",
     "weekStartMonday": "Maandag",
-    "weekStartSunday": "Zondag",
-    "smoothZoom": "Vloeiende zoom-animatie"
+    "weekStartSunday": "Zondag"
   },
   "confirm": {
     "newProject": "Nieuw project aanmaken? Niet-opgeslagen wijzigingen gaan verloren.",

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -34,7 +34,16 @@
     "version": "Versie",
     "defaultZoom": "Standaard zoom",
     "projectInfo": "Projectinformatie...",
-    "theme": "Thema"
+    "theme": "Thema",
+    "timeline": "Tijdlijn / Zoomen",
+    "mouseWheelMode": "Muiswiel-gedrag",
+    "mouseWheelModeZoom": "Zoomen",
+    "mouseWheelModeScroll": "Scrollen",
+    "enableQuarterHourZoom": "Kwartieren tonen bij ver inzoomen",
+    "weekStartDay": "Week begint op",
+    "weekStartMonday": "Maandag",
+    "weekStartSunday": "Zondag",
+    "smoothZoom": "Vloeiende zoom-animatie"
   },
   "confirm": {
     "newProject": "Nieuw project aanmaken? Niet-opgeslagen wijzigingen gaan verloren.",

--- a/src/state/appStore.ts
+++ b/src/state/appStore.ts
@@ -195,6 +195,10 @@ function createDefaultUI(): UIState {
     inlineEditTaskId: null,
     showSettingsDialog: false,
     uiTheme: 'default',
+    mouseWheelMode: 'zoom',
+    enableQuarterHourZoom: false,
+    weekStartDay: 'monday',
+    smoothZoom: false,
   };
 }
 
@@ -534,7 +538,8 @@ export const useAppStore = create<AppState>()(
     // --- View ---
     setZoom: (zoom) =>
       set((s) => {
-        s.view.zoom = Math.max(1, Math.min(200, zoom));
+        const max = s.ui.enableQuarterHourZoom ? 1000 : 400;
+        s.view.zoom = Math.max(0.5, Math.min(max, zoom));
       }),
 
     setTimeScale: (scale) =>
@@ -557,6 +562,8 @@ export const useAppStore = create<AppState>()(
     setUI: (updates) =>
       set((s) => {
         Object.assign(s.ui, updates);
+        const max = s.ui.enableQuarterHourZoom ? 1000 : 400;
+        if (s.view.zoom > max) s.view.zoom = max;
       }),
 
     // --- Collapse/expand ---

--- a/src/state/appStore.ts
+++ b/src/state/appStore.ts
@@ -195,10 +195,8 @@ function createDefaultUI(): UIState {
     inlineEditTaskId: null,
     showSettingsDialog: false,
     uiTheme: 'default',
-    mouseWheelMode: 'zoom',
     enableQuarterHourZoom: false,
     weekStartDay: 'monday',
-    smoothZoom: false,
   };
 }
 

--- a/src/state/slices/types.ts
+++ b/src/state/slices/types.ts
@@ -1,5 +1,8 @@
 export type TimeScale = 'day' | 'week' | 'month' | 'quarter';
 
+export type MouseWheelMode = 'zoom' | 'scroll';
+export type WeekStartDay = 'monday' | 'sunday';
+
 export type UITheme = 'default' | 'light' | 'dark' | 'blue' | 'amber-navy' | 'warm-ember' | 'highContrast';
 
 export const UI_THEMES: { id: UITheme; label: string }[] = [
@@ -38,4 +41,8 @@ export interface UIState {
   inlineEditTaskId: string | null;
   showSettingsDialog: boolean;
   uiTheme: UITheme;
+  mouseWheelMode: MouseWheelMode;
+  enableQuarterHourZoom: boolean;
+  weekStartDay: WeekStartDay;
+  smoothZoom: boolean;
 }

--- a/src/state/slices/types.ts
+++ b/src/state/slices/types.ts
@@ -1,6 +1,5 @@
 export type TimeScale = 'day' | 'week' | 'month' | 'quarter';
 
-export type MouseWheelMode = 'zoom' | 'scroll';
 export type WeekStartDay = 'monday' | 'sunday';
 
 export type UITheme = 'default' | 'light' | 'dark' | 'blue' | 'amber-navy' | 'warm-ember' | 'highContrast';
@@ -41,8 +40,6 @@ export interface UIState {
   inlineEditTaskId: string | null;
   showSettingsDialog: boolean;
   uiTheme: UITheme;
-  mouseWheelMode: MouseWheelMode;
   enableQuarterHourZoom: boolean;
   weekStartDay: WeekStartDay;
-  smoothZoom: boolean;
 }

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -41,6 +41,19 @@ export function getWeekStart(d: Date): Date {
   return result;
 }
 
+/** Get the Sunday of the week containing the given date (used when weekStartDay='sunday') */
+export function getWeekStartSunday(d: Date): Date {
+  const result = new Date(d.getTime());
+  const dow = result.getUTCDay(); // 0=Sun..6=Sat
+  result.setUTCDate(result.getUTCDate() - dow);
+  return result;
+}
+
+/** Get the start of the week respecting the week-start-day preference */
+export function getWeekStartFor(d: Date, startDay: 'monday' | 'sunday'): Date {
+  return startDay === 'sunday' ? getWeekStartSunday(d) : getWeekStart(d);
+}
+
 /** Get the first day of the month */
 export function getMonthStart(d: Date): Date {
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
@@ -67,4 +80,14 @@ export function getWeekNumber(d: Date): number {
   target.setUTCDate(target.getUTCDate() + 3 - ((target.getUTCDay() + 6) % 7));
   const jan4 = new Date(Date.UTC(target.getUTCFullYear(), 0, 4));
   return 1 + Math.round(((target.getTime() - jan4.getTime()) / 86400000 - 3 + ((jan4.getUTCDay() + 6) % 7)) / 7);
+}
+
+/** Get week number with configurable week start. ISO 8601 when 'monday', US-style when 'sunday'. */
+export function getWeekNumberFor(d: Date, startDay: 'monday' | 'sunday' = 'monday'): number {
+  if (startDay === 'monday') return getWeekNumber(d);
+  // US-style: week 1 contains Jan 1; weeks start Sunday.
+  const target = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const jan1 = new Date(Date.UTC(target.getUTCFullYear(), 0, 1));
+  const dayOfYear = Math.floor((target.getTime() - jan1.getTime()) / 86400000);
+  return Math.floor((dayOfYear + jan1.getUTCDay()) / 7) + 1;
 }

--- a/src/utils/settingsStore.ts
+++ b/src/utils/settingsStore.ts
@@ -1,3 +1,5 @@
+import type { MouseWheelMode, WeekStartDay } from '@/state/slices/types';
+
 export async function getSetting<T>(key: string): Promise<T | undefined> {
   const raw = localStorage.getItem(`ops-${key}`);
   if (raw === null) return undefined;
@@ -26,4 +28,31 @@ export async function saveTheme(theme: string): Promise<void> {
 export async function initTheme(): Promise<string> {
   const saved = localStorage.getItem('ops-theme');
   return saved || 'default';
+}
+
+export interface PersistedZoomSettings {
+  mouseWheelMode: MouseWheelMode;
+  enableQuarterHourZoom: boolean;
+  weekStartDay: WeekStartDay;
+  smoothZoom: boolean;
+}
+
+export async function loadZoomSettings(): Promise<Partial<PersistedZoomSettings>> {
+  const result: Partial<PersistedZoomSettings> = {};
+  const wheel = await getSetting<MouseWheelMode>('mouseWheelMode');
+  const qh = await getSetting<boolean>('enableQuarterHourZoom');
+  const week = await getSetting<WeekStartDay>('weekStartDay');
+  const smooth = await getSetting<boolean>('smoothZoom');
+  if (wheel === 'zoom' || wheel === 'scroll') result.mouseWheelMode = wheel;
+  if (typeof qh === 'boolean') result.enableQuarterHourZoom = qh;
+  if (week === 'monday' || week === 'sunday') result.weekStartDay = week;
+  if (typeof smooth === 'boolean') result.smoothZoom = smooth;
+  return result;
+}
+
+export async function saveZoomSettings(settings: Partial<PersistedZoomSettings>): Promise<void> {
+  if (settings.mouseWheelMode !== undefined) await setSetting('mouseWheelMode', settings.mouseWheelMode);
+  if (settings.enableQuarterHourZoom !== undefined) await setSetting('enableQuarterHourZoom', settings.enableQuarterHourZoom);
+  if (settings.weekStartDay !== undefined) await setSetting('weekStartDay', settings.weekStartDay);
+  if (settings.smoothZoom !== undefined) await setSetting('smoothZoom', settings.smoothZoom);
 }

--- a/src/utils/settingsStore.ts
+++ b/src/utils/settingsStore.ts
@@ -1,4 +1,4 @@
-import type { MouseWheelMode, WeekStartDay } from '@/state/slices/types';
+import type { WeekStartDay } from '@/state/slices/types';
 
 export async function getSetting<T>(key: string): Promise<T | undefined> {
   const raw = localStorage.getItem(`ops-${key}`);
@@ -31,28 +31,20 @@ export async function initTheme(): Promise<string> {
 }
 
 export interface PersistedZoomSettings {
-  mouseWheelMode: MouseWheelMode;
   enableQuarterHourZoom: boolean;
   weekStartDay: WeekStartDay;
-  smoothZoom: boolean;
 }
 
 export async function loadZoomSettings(): Promise<Partial<PersistedZoomSettings>> {
   const result: Partial<PersistedZoomSettings> = {};
-  const wheel = await getSetting<MouseWheelMode>('mouseWheelMode');
   const qh = await getSetting<boolean>('enableQuarterHourZoom');
   const week = await getSetting<WeekStartDay>('weekStartDay');
-  const smooth = await getSetting<boolean>('smoothZoom');
-  if (wheel === 'zoom' || wheel === 'scroll') result.mouseWheelMode = wheel;
   if (typeof qh === 'boolean') result.enableQuarterHourZoom = qh;
   if (week === 'monday' || week === 'sunday') result.weekStartDay = week;
-  if (typeof smooth === 'boolean') result.smoothZoom = smooth;
   return result;
 }
 
 export async function saveZoomSettings(settings: Partial<PersistedZoomSettings>): Promise<void> {
-  if (settings.mouseWheelMode !== undefined) await setSetting('mouseWheelMode', settings.mouseWheelMode);
   if (settings.enableQuarterHourZoom !== undefined) await setSetting('enableQuarterHourZoom', settings.enableQuarterHourZoom);
   if (settings.weekStartDay !== undefined) await setSetting('weekStartDay', settings.weekStartDay);
-  if (settings.smoothZoom !== undefined) await setSetting('smoothZoom', settings.smoothZoom);
 }


### PR DESCRIPTION
## Summary

- **Cursor-anchored zoom** (Ctrl+wheel) — date under the mouse stays in place when zooming.
- **Fixed wheel mapping**: plain wheel = horizontal scroll, Shift+wheel = vertical scroll, Ctrl+wheel = zoom.
- **Adaptive timeline header** with 7 tiers (year > quarter > month > week > day > hour > quarter-hour). Fixes the glitch at low zoom.
- **Keyboard shortcuts**: `+` / `-` zoom, `0` reset, `Ctrl+0` fit-to-project (horizontal and vertical).
- **Bug fix**: horizontal scroll went out of sync after zoom.
- **Settings tab "Tijdlijn / Zoomen"** with week-start day (Monday/Sunday) and quarter-hour zoom toggle. Settings persisted to localStorage.
- **Bonus** (earlier in same branch): name field in TaskDialog is auto-selected when double-clicking a task.

## Architecture

- `src/engine/renderer/timelineTiers.ts` — pure tier table + selector.
- `src/hooks/useGanttZoom.ts` — wheel handler with cursor-anchored zoom.
- `src/hooks/useZoomShortcuts.ts` — keyboard shortcuts.
- `src/engine/renderer/GanttRenderer.ts` — `drawTimelineHeader` rewritten, tier-driven.
- `src/state/slices/types.ts` + `appStore.ts` — added `weekStartDay` + `enableQuarterHourZoom`, dynamic zoom clamp.
- `src/components/dialogs/SettingsDialog.tsx` — new Timeline tab.

Spec: `docs/superpowers/specs/2026-05-01-zoom-improvements-design.md`
Plan: `docs/superpowers/plans/2026-05-01-zoom-improvements.md`

## Test plan

- [ ] Plain wheel scrolls horizontally, Shift+wheel vertically, Ctrl+wheel zooms toward cursor.
- [ ] Header shows correct tiers at all zoom thresholds (1.5, 4, 10, 25, 80, 400).
- [ ] No overlapping labels when zoomed far out.
- [ ] Horizontal scroll stays in sync after zoom.
- [ ] `Ctrl+0` fits the project to the screen.
- [ ] Settings (week-start, quarter-hour zoom) survive reload.
- [ ] Double-click on task block selects the name in the dialog immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
