### PR TITLE
Rust/JS werkverdeling: algoritmische fixes, isTauri-util, Rust escape-hatch docs

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,6 +10,8 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-store = "2"
 tauri-plugin-os = "2"
+# Behouden voor de native command-escape-hatch (src/commands/mod.rs): payload-
+# (de)serialisatie zodra die commands gestructureerde data gaan dragen.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,10 +1,23 @@
+//! Native bestand-I/O-commands — een bewuste IPC-"escape hatch".
+//!
+//! Deze worden NIET door de frontend gebruikt: alle bestand-I/O loopt via de
+//! JS-plugins `@tauri-apps/plugin-fs` + `@tauri-apps/plugin-dialog`, en er staat
+//! nergens `invoke()` in `src/`. Ze blijven bewust staan als kant-en-klare
+//! native fallback voor bewerkingen die de JS-plugins niet aankunnen (zeer grote
+//! bestanden streamen, eigen pad-afhandeling, OS-specifiek gedrag). Verwijder je
+//! ze, verwijder dan ook deze notitie en de `serde`/`serde_json`-deps.
+
 use std::fs;
 
+/// Lees een UTF-8-bestand van schijf. Escape-hatch-command (zie module-docs) —
+/// ongebruikt door de frontend, die bestanden leest via de JS-`plugin-fs`.
 #[tauri::command]
 pub fn read_file(path: String) -> Result<String, String> {
     fs::read_to_string(&path).map_err(|e| format!("Failed to read {}: {}", path, e))
 }
 
+/// Schrijf een UTF-8-bestand naar schijf. Escape-hatch-command (zie module-docs)
+/// — ongebruikt door de frontend, die bestanden schrijft via de JS-`plugin-fs`.
 #[tauri::command]
 pub fn write_file(path: String, contents: String) -> Result<(), String> {
     fs::write(&path, &contents).map_err(|e| format!("Failed to write {}: {}", path, e))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,9 @@ fn main() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_os::init())
+        // Bewuste native IPC-escape-hatch — deze commands zijn vandaag ongebruikt
+        // door de frontend (die gebruikt de JS-fs/dialog-plugins). Zie
+        // commands/mod.rs voordat je ze verwijdert.
         .invoke_handler(tauri::generate_handler![
             commands::read_file,
             commands::write_file,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { initTheme, loadZoomSettings, loadDebugTerminalEnabled } from '@/utils/s
 import { loadAllExtensions } from '@/extensions';
 import { writeIFC } from '@/services/ifc/ifcWriter';
 import { readIFC } from '@/services/ifc/ifcReader';
-const isTauri = () => '__TAURI_INTERNALS__' in window;
+import { isTauri } from '@/utils/platform';
 
 // The recovery file lives in the shared appDataDir (app-id org.openaec.planner),
 // so concurrent dev builds from different worktrees would clobber each other.

--- a/src/components/layout/TitleBar/TitleBar.tsx
+++ b/src/components/layout/TitleBar/TitleBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAppStore } from '@/state/appStore';
 import { useTranslation } from 'react-i18next';
-const isTauri = () => '__TAURI_INTERNALS__' in window;
+import { isTauri } from '@/utils/platform';
 import {
   FileText, FolderOpen, Save, Undo2, Redo2, Minus, Square, Copy, X, Settings,
 } from 'lucide-react';

--- a/src/components/panels/ReportPanel.tsx
+++ b/src/components/panels/ReportPanel.tsx
@@ -5,7 +5,7 @@ import { renderPrintCanvas, PrintOptions } from '@/services/print/printPreview';
 import { getLocalizedMonths, getLocalizedMonthsShort } from '@/i18n/dateFormat';
 import { ensureExtension } from '@/utils/filePath';
 import { Select } from '@/components/common/Select';
-const isTauri = () => '__TAURI_INTERNALS__' in window;
+import { isTauri } from '@/utils/platform';
 
 export function ReportPanel() {
   const { t } = useTranslation('report');

--- a/src/engine/renderer/GanttRenderer.ts
+++ b/src/engine/renderer/GanttRenderer.ts
@@ -61,6 +61,7 @@ export class GanttRenderer {
   // Computed
   private viewStart: Date;
   private flatTasks: Task[]; // flattened task list in display order
+  private flatTaskIndex: Map<string, number>; // task id -> row index in flatTasks
   private taskDepths: Map<string, number>; // task id -> nesting depth
   private holidaySet: Set<string>;
 
@@ -72,6 +73,7 @@ export class GanttRenderer {
     this.viewStart = parseDate(opts.view.viewStartDate);
     this.taskDepths = new Map();
     this.flatTasks = this.flattenTasks(opts.tasks);
+    this.flatTaskIndex = new Map(this.flatTasks.map((t, i) => [t.id, i]));
     this.holidaySet = new Set<string>();
     this.buildHolidaySet();
   }
@@ -456,8 +458,8 @@ export class GanttRenderer {
     ctx.lineWidth = 1;
 
     for (const seq of this.opts.sequences) {
-      const predIdx = this.flatTasks.findIndex(t => t.id === seq.predecessorId);
-      const succIdx = this.flatTasks.findIndex(t => t.id === seq.successorId);
+      const predIdx = this.flatTaskIndex.get(seq.predecessorId) ?? -1;
+      const succIdx = this.flatTaskIndex.get(seq.successorId) ?? -1;
       if (predIdx < 0 || succIdx < 0) continue;
 
       const pred = this.flatTasks[predIdx];

--- a/src/services/ifc/ifcReader.ts
+++ b/src/services/ifc/ifcReader.ts
@@ -311,25 +311,27 @@ function extractNesting(
   taskStepIdMap: Map<string, string>,
 ): void {
   const nestEntities = entities.filter(e => e.type === 'IFCRELNESTS');
+  // Index tasks by id once. Voorheen werd elke parent/child via tasks.find()
+  // in de lus opgezocht, waardoor nesting O(nestings × children × tasks) was.
+  const taskById = new Map<string, Task>(tasks.map(t => [t.id, t]));
 
   for (const ne of nestEntities) {
     const parentRef = parseRef(ne.args[4] || '');
     if (!parentRef) continue;
     const parentId = taskStepIdMap.get(parentRef);
     if (!parentId) continue; // Could be WorkSchedule, skip
+    const parent = taskById.get(parentId);
+    if (!parent) continue;
 
     const childRefs = parseRefs(ne.args[5] || '');
     for (const childRef of childRefs) {
       const childId = taskStepIdMap.get(childRef);
-      if (childId) {
-        const child = tasks.find(t => t.id === childId);
-        const parent = tasks.find(t => t.id === parentId);
-        if (child && parent) {
-          child.parentId = parentId;
-          if (!parent.childIds.includes(childId)) {
-            parent.childIds.push(childId);
-          }
-        }
+      if (!childId) continue;
+      const child = taskById.get(childId);
+      if (!child) continue;
+      child.parentId = parentId;
+      if (!parent.childIds.includes(childId)) {
+        parent.childIds.push(childId);
       }
     }
   }

--- a/src/state/slices/fileSlice.ts
+++ b/src/state/slices/fileSlice.ts
@@ -9,8 +9,7 @@ import { readP6XML } from '@/services/p6/p6xmlReader';
 import { ensureExtension } from '@/utils/filePath';
 import { emitExtensionEvent, HOST_EVENTS } from '@/extensions/eventBus';
 import type { AppSlice } from './types';
-
-const isTauri = () => '__TAURI_INTERNALS__' in window;
+import { isTauri } from '@/utils/platform';
 
 /** Kies de juiste XML-reader op basis van inhoudsmarkers (P6 vóór MS Project).
  *  Gooit bij een onbekend formaat i.p.v. stil als MSPDI te parsen. */

--- a/src/utils/devBridge.ts
+++ b/src/utils/devBridge.ts
@@ -5,6 +5,7 @@ import { readIFC } from '@/services/ifc/ifcReader';
 import { readCSV } from '@/services/csv/csvReader';
 import { enableExtension, disableExtension, removeExtension, saveExtensionToDb } from '@/extensions';
 import type { ExtensionManifest, InstalledExtension } from '@/extensions/types';
+import { isTauri } from '@/utils/platform';
 
 /**
  * Dev-only inspectie- en controle-haak voor geautomatiseerd zelf-testen.
@@ -23,8 +24,6 @@ import type { ExtensionManifest, InstalledExtension } from '@/extensions/types';
  * STRIKT dev-only: aangeroepen achter `import.meta.env.DEV` (main.tsx) via dynamische import,
  * dus dit verdwijnt volledig uit productie-builds. De poller start alleen in de Tauri-runtime.
  */
-
-const isTauri = () => '__TAURI_INTERNALS__' in window;
 
 type AppState = ReturnType<typeof useAppStore.getState>;
 

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,8 @@
+/**
+ * Runtime-platformdetectie: de naad tussen de web-build en de Tauri-desktopschil.
+ *
+ * Tauri injecteert `__TAURI_INTERNALS__` op `window`; in een kale browser ontbreekt
+ * het. Code die `@tauri-apps/*` aanraakt moet hier eerst doorheen (dynamische import
+ * binnen een `isTauri()`-tak), anders breekt de web-build.
+ */
+export const isTauri = (): boolean => '__TAURI_INTERNALS__' in window;


### PR DESCRIPTION
## Samenvatting
Uitkomst van de rust/JS-werkverdeling-analyse: domeinlogica blijft in TS, Rust blijft dun. Drie gerichte verbeteringen, geen logica naar Rust verplaatst.

- **perf:** `extractNesting` (IFC-reader) O(n³)→O(n) via `Map<id,Task>`; `drawDependencyArrows` (Gantt) O(seq×taken)→O(seq) via een `flatTaskIndex`-Map. Gedrag identiek (unieke ids).
- **refactor:** `isTauri()` (5× gedupliceerd) gecentraliseerd in `src/utils/platform.ts`.
- **docs:** `read_file`/`write_file` + `serde` gedocumenteerd als bewuste native escape-hatch (geen dode code).

## Testplan
- [x] `npm run build` (tsc strict + vite) groen
- [x] `cargo check` exit 0; volledige `tauri:dev`-build draait
- [x] Browser-self-test: genest project + afhankelijkheid → `runCPM` → IFC round-trip lossless → Gantt rendert samenvattingsbalk + B→C-pijl, geen console-fouten