### PR TITLE
docs(readme): architectuur klopt nu — extensies/styling van Open Calc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ examples/            # Voorbeeld IFC-planningen
 
 ## Architectuur
 
-Volgt het patroon van [Open 2D Studio](https://github.com/OpenAEC-Foundation/Open-2D-Studio) en [Open FEM2D Studio](https://github.com/OpenAEC-Foundation/Open-FEM2D-Studio).
+Onderdeel van de OpenAEC-Foundation-familie van desktop-apps, die een gedeeld patroon delen (Tauri 2 + React + Canvas, Office-achtige ribbon, `lucide-react`). De algehele shell volgt [Open 2D Studio](https://github.com/OpenAEC-Foundation/Open-2D-Studio) en [Open FEM2D Studio](https://github.com/OpenAEC-Foundation/Open-FEM2D-Studio); het [extensiesysteem](docs/extensions.md) en de huidige styling zijn gemodelleerd naar [Open Calc Studio](https://github.com/OpenAEC-Foundation/open-calc-studio).
 
 Zie [PLAN.md](PLAN.md) voor het volledige projectplan.
 


### PR DESCRIPTION
… Studio

De architectuursectie noemde alleen Open 2D Studio en OpenFEM2D Studio, terwijl het extensiesysteem en de huidige styling gemodelleerd zijn naar Open Calc Studio. Beschrijft de app nu als deel van de OpenAEC-familie met een gedeeld patroon, en attribueert elk onderdeel correct.


Claude-Session: https://claude.ai/code/session_01ACLHLuaNgH9Qy8rwbeowBn