### PR TITLE
Add write permission to auto-assign issues workflow

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -2,6 +2,8 @@ name: Auto-assign issues to product owner
 on:
   issues:
     types: [opened]
+permissions:
+  issues: write
 jobs:
   assign:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow for auto-assigning issues to explicitly declare the required `issues: write` permission.

## Changes
- Added `permissions` section to `.github/workflows/auto-assign-issues.yml` with `issues: write` permission

## Details
This change ensures the workflow has the necessary permissions to modify issues when auto-assigning them to the product owner. This follows GitHub Actions best practices of explicitly declaring required permissions rather than relying on default token permissions.

https://claude.ai/code/session_01J4TFPJbvbU4bXVfSEcLJpZ