### PR TITLE
fix(self-test): wijs Playwright MCP naar pre-installed chromium

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium", "--headless"]
+      "args": ["-y", "@playwright/mcp@latest", "--browser", "chromium", "--headless", "--executable-path", "/opt/pw-browsers/chromium-1194/chrome-linux/chrome"]
     }
   }
 }


### PR DESCRIPTION
@playwright/mcp@latest resolvet --browser chromium nu naar het
chrome-for-testing-kanaal en wil chromium v1229 downloaden, wat de
netwerkpolicy in de remote-omgeving blokkeert. De omgeving heeft al
een werkende chromium-1194; via --executable-path gebruiken we die,
zodat de Tier 1 self-test-harness zonder download werkt.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PqK5fMxKVchw2CZQcfE29V