### PR TITLE
fix(ifc): ontkoppel de baseline-remap van de GUID-hash, dan pas de botsingscheck (item 29 / B8)

### DIFF
--- a/src/services/ifc/ifcReader.ts
+++ b/src/services/ifc/ifcReader.ts
@@ -1608,6 +1608,8 @@ function extractBaselines(
 
   let baselines: Baseline[] = [];
   let activeBaselineId: string | null = null;
+  /** Expliciete interne-taakId → GlobalId-map uit het bestand (B8); leeg bij oudere bestanden. */
+  let taskGuids: Record<string, string> | null = null;
 
   for (const e of entities) {
     if (e.type !== 'IFCPROPERTYSET' || stripQuotes(e.args[2] || '') !== PSET.Baselines) continue;
@@ -1624,6 +1626,16 @@ function extractBaselines(
         } catch { /* corrupte JSON — negeer, baselines blijft leeg */ }
       } else if (name === 'ActiveBaselineId') {
         activeBaselineId = raw;
+      } else if (name === 'TaskGuids') {
+        // Bevinding B8: de writer schrijft sinds deze versie expliciet weg wélk GlobalId hij per
+        // baseline-taak gebruikte, zodat wij de hash niet meer hoeven na te rekenen. Ontbreekt de
+        // map (bestanden van vóór die wijziging), dan valt de remap hieronder terug op de oude weg.
+        try {
+          const parsed: unknown = JSON.parse(raw);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            taskGuids = parsed as Record<string, string>;
+          }
+        } catch { /* corrupte JSON — negeer, we vallen terug op herberekening */ }
       }
     }
   }
@@ -1632,7 +1644,10 @@ function extractBaselines(
   for (const b of baselines) {
     if (!Array.isArray(b.tasks)) { b.tasks = []; continue; }
     for (const bt of b.tasks as BaselineTask[]) {
-      const remapped = guidToTaskId.get(ifcGuid(bt.taskId));
+      // B8: gebruik het GlobalId dat de writer daadwerkelijk uitgaf. Alleen bij bestanden van
+      // vóór de `TaskGuids`-map vallen we terug op het herberekenen van de hash.
+      const guid = taskGuids?.[bt.taskId] ?? ifcGuid(bt.taskId);
+      const remapped = guidToTaskId.get(guid);
       if (remapped) bt.taskId = remapped;
     }
   }

--- a/src/services/ifc/ifcWriter.ts
+++ b/src/services/ifc/ifcWriter.ts
@@ -71,6 +71,37 @@ interface WriteContext {
   lines: string[];
   nextId: number;
   idMap: Map<string, number>; // our ID -> STEP #id
+  /** seed → daadwerkelijk uitgegeven GlobalId (bevinding B8). */
+  guids: Map<string, string>;
+  /** Alle uitgegeven GlobalIds, om botsingen te detecteren (bevinding B8). */
+  usedGuids: Set<string>;
+}
+
+/**
+ * Geef het GlobalId uit voor `seed` — en garandeer dat het uniek is binnen dit bestand.
+ *
+ * Bevinding B8: `ifcGuid` is een 32-bits hash, geen UUID en geen conforme IFC-GUID. Over 20.000
+ * realistische id's zijn geen botsingen gemeten, maar 32 bits plus een niet-uniforme mixer maakt
+ * een verjaardagsbotsing bij tienduizenden id's niet uit te sluiten — en er was geen detectie.
+ * Een botsing gaf stille kruisbesmetting van baselines of toewijzingen.
+ *
+ * Dit is de enige plek die GlobalIds uitgeeft. Botst een hash met een eerder uitgegeven GlobalId,
+ * dan wordt er deterministisch doorgezocht met een gesuffixte seed. Zonder botsing is de uitkomst
+ * BYTE-IDENTIEK aan `guidOf(ctx, seed)` — bestaande bestanden veranderen dus niet.
+ *
+ * LET OP de volgorde waarin B8 is aangepakt: de ontkoppeling (de writer schrijft expliciet weg
+ * wélk GlobalId hij per taak gebruikte, zie `writeBaselineMeta`) moest EERST. Een botsingscheck
+ * zónder die ontkoppeling zou de baseline-remap breken, want de reader herberekende de hash zelf
+ * en zou een gesuffixt GlobalId nooit terugvinden.
+ */
+function guidOf(ctx: WriteContext, seed: string): string {
+  const cached = ctx.guids.get(seed);
+  if (cached !== undefined) return cached;
+  let guid = ifcGuid(seed);
+  for (let n = 1; ctx.usedGuids.has(guid); n++) guid = ifcGuid(`${seed}#dup${n}`);
+  ctx.guids.set(seed, guid);
+  ctx.usedGuids.add(guid);
+  return guid;
 }
 
 function ref(ctx: WriteContext, key: string): string {
@@ -105,7 +136,7 @@ export function writeIFC(input: WriteIFCInput): string {
     activeBaselineId = null,
     libraryPool = undefined,
   } = input;
-  const ctx: WriteContext = { lines: [], nextId: 1, idMap: new Map() };
+  const ctx: WriteContext = { lines: [], nextId: 1, idMap: new Map(), guids: new Map(), usedGuids: new Set() };
   const now = new Date().toISOString().split('.')[0];
 
   // Header. Naam/auteur/bedrijf MOETEN door `ifcStr` (bevinding K2): ze werden rauw
@@ -161,7 +192,7 @@ export function writeIFC(input: WriteIFCInput): string {
 
   // Project. Description (arg 3) draagt project.description (fase 3, H2) — de reader leest 'm terug
   // uit de IFCWORKPLAN.Description-slot, met terugval op deze.
-  addLine(ctx, '_project', `IFCPROJECT(${ifcStr(ifcGuid(project.id))},#${ownerHistId},${ifcStr(project.name)},${ifcStr(project.description)},$,$,$,(#${ctxId}),#${unitAssId})`);
+  addLine(ctx, '_project', `IFCPROJECT(${ifcStr(guidOf(ctx, project.id))},#${ownerHistId},${ifcStr(project.name)},${ifcStr(project.description)},$,$,$,(#${ctxId}),#${unitAssId})`);
 
   // Calendar (projectkalender — altijd de EERSTE IFCWORKCALENDAR in het bestand; vaste conventie
   // die de reader aanhoudt om 'm van de bibliotheek-kalenders hieronder te onderscheiden, §8.2).
@@ -175,10 +206,10 @@ export function writeIFC(input: WriteIFCInput): string {
   const planEnd = endDates[endDates.length - 1] || project.endDate;
 
   const workPlanId = addLine(ctx, '_workplan',
-    `IFCWORKPLAN(${ifcStr(ifcGuid(project.id + '_wp'))},#${ownerHistId},${ifcStr(project.name)},${ifcStr(project.description)},$,$,${ifcDateTime(now)},$,$,$,$,$,${ifcDateTime(planStart)},${ifcDateTime(planEnd)},.PLANNED.)`);
+    `IFCWORKPLAN(${ifcStr(guidOf(ctx, project.id + '_wp'))},#${ownerHistId},${ifcStr(project.name)},${ifcStr(project.description)},$,$,${ifcDateTime(now)},$,$,$,$,$,${ifcDateTime(planStart)},${ifcDateTime(planEnd)},.PLANNED.)`);
 
   const workSchedId = addLine(ctx, '_worksched',
-    `IFCWORKSCHEDULE(${ifcStr(ifcGuid(project.id + '_ws'))},#${ownerHistId},${ifcStr('Construction schedule v1.0')},$,$,$,${ifcDateTime(now)},$,$,$,$,$,${ifcDateTime(planStart)},${ifcDateTime(planEnd)},.PLANNED.)`);
+    `IFCWORKSCHEDULE(${ifcStr(guidOf(ctx, project.id + '_ws'))},#${ownerHistId},${ifcStr('Construction schedule v1.0')},$,$,$,${ifcDateTime(now)},$,$,$,$,$,${ifcDateTime(planStart)},${ifcDateTime(planEnd)},.PLANNED.)`);
 
   // Baselines (fase 2.6, §8.3) — per baseline één `.BASELINE.`-IfcWorkSchedule-header (Name +
   // CreationDate, ZONDER taak-duplicatie: de datums leven verliesloos in het OPS_Baselines-JSON
@@ -187,13 +218,13 @@ export function writeIFC(input: WriteIFCInput): string {
   const baselineSchedRefs: string[] = [];
   for (const b of baselines) {
     const bId = addLine(ctx, `_baseline_ws_${b.id}`,
-      `IFCWORKSCHEDULE(${ifcStr(ifcGuid('baseline_ws_' + b.id))},#${ownerHistId},${ifcStr(b.name)},$,$,$,${ifcDateTime(b.createdAt)},$,$,$,$,$,$,${ifcDateTime(b.projectEnd)},.BASELINE.)`);
+      `IFCWORKSCHEDULE(${ifcStr(guidOf(ctx, 'baseline_ws_' + b.id))},#${ownerHistId},${ifcStr(b.name)},$,$,$,${ifcDateTime(b.createdAt)},$,$,$,$,$,$,${ifcDateTime(b.projectEnd)},.BASELINE.)`);
     baselineSchedRefs.push(`#${bId}`);
   }
 
   const schedRefs = [`#${workSchedId}`, ...baselineSchedRefs].join(',');
   addLine(ctx, '_agg_plan_sched',
-    `IFCRELAGGREGATES(${ifcStr(ifcGuid('agg_ps'))},#${ownerHistId},$,$,#${workPlanId},(${schedRefs}))`);
+    `IFCRELAGGREGATES(${ifcStr(guidOf(ctx, 'agg_ps'))},#${ownerHistId},$,$,#${workPlanId},(${schedRefs}))`);
 
   // Tasks. Fase 2.8b (§7.1): per taak de effectieve kalender bepaalt uur- vs dag-modus
   // (uur ⇒ echte tijden + minuut-duren; dag ⇒ byte-identiek `T07:00:00` + `P0Y0M{days}D`).
@@ -211,7 +242,7 @@ export function writeIFC(input: WriteIFCInput): string {
   if (rootTasks.length > 0) {
     const rootRefs = rootTasks.map(t => ref(ctx, `task_${t.id}`)).join(',');
     addLine(ctx, '_nest_sched',
-      `IFCRELNESTS(${ifcStr(ifcGuid('nest_root'))},#${ownerHistId},'WBS Hoofd',$,#${workSchedId},(${rootRefs}))`);
+      `IFCRELNESTS(${ifcStr(guidOf(ctx, 'nest_root'))},#${ownerHistId},'WBS Hoofd',$,#${workSchedId},(${rootRefs}))`);
   }
 
   // Sequences
@@ -242,7 +273,7 @@ export function writeIFC(input: WriteIFCInput): string {
   if (tasks.length > 0) {
     const allTaskRefs = tasks.map(t => ref(ctx, `task_${t.id}`)).join(',');
     addLine(ctx, '_ctrl',
-      `IFCRELASSIGNSTOCONTROL(${ifcStr(ifcGuid('ctrl'))},#${ownerHistId},$,$,(${allTaskRefs}),$,#${workSchedId})`);
+      `IFCRELASSIGNSTOCONTROL(${ifcStr(guidOf(ctx, 'ctrl'))},#${ownerHistId},$,$,(${allTaskRefs}),$,#${workSchedId})`);
   }
 
   // Structuurdefinities (activity codes / custom fields) + waarden per taak + projectsettings
@@ -313,7 +344,7 @@ function writeStructure(
   const projRef = ref(ctx, '_project');
   const relDefines = (key: string, objRef: string, setId: number) =>
     addLine(ctx, key,
-      `IFCRELDEFINESBYPROPERTIES(${ifcStr(ifcGuid(key))},#${ownerHistId},$,$,(${objRef}),#${setId})`);
+      `IFCRELDEFINESBYPROPERTIES(${ifcStr(guidOf(ctx, key))},#${ownerHistId},$,$,(${objRef}),#${setId})`);
 
   // Projectsettings — wbsAutoNumber (fase 2.2) + statusDate/progressMode (fase 2.6, §8.2).
   // Golden rule: elk veld alleen wanneer gezet; geen enkel veld ⇒ geen OPS_ProjectSettings-pset.
@@ -376,7 +407,7 @@ function writeStructure(
   }
   if (projSettingProps.length > 0) {
     const setId = addLine(ctx, '_pset_projset',
-      `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_projset'))},#${ownerHistId},${ifcStr(PSET.ProjectSettings)},$,(${projSettingProps.map(i => `#${i}`).join(',')}))`);
+      `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_projset'))},#${ownerHistId},${ifcStr(PSET.ProjectSettings)},$,(${projSettingProps.map(i => `#${i}`).join(',')}))`);
     relDefines('_rel_projset', projRef, setId);
   }
 
@@ -387,7 +418,7 @@ function writeStructure(
   const metaPropId = addLine(ctx, '_ps_structmeta',
     `IFCPROPERTYSINGLEVALUE('structure',$,IFCTEXT(${ifcStr(metaJson)}),$)`);
   const metaSetId = addLine(ctx, '_pset_structmeta',
-    `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_structmeta'))},#${ownerHistId},${ifcStr(PSET.StructureMeta)},$,(#${metaPropId}))`);
+    `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_structmeta'))},#${ownerHistId},${ifcStr(PSET.StructureMeta)},$,(#${metaPropId}))`);
   relDefines('_rel_structmeta', projRef, metaSetId);
 
   // Conformante templates + declaratie aan het project.
@@ -395,11 +426,11 @@ function writeStructure(
   if (customFieldDefs.length > 0) {
     const fieldTmplRefs = customFieldDefs.map(def => {
       const id = addLine(ctx, `_cft_${def.id}`,
-        `IFCSIMPLEPROPERTYTEMPLATE(${ifcStr(ifcGuid('cft_' + def.id))},#${ownerHistId},${ifcStr(def.name)},$,.P_SINGLEVALUE.,${ifcStr(FIELD_MEASURE[def.type])},$,$,$,$,$,$)`);
+        `IFCSIMPLEPROPERTYTEMPLATE(${ifcStr(guidOf(ctx, 'cft_' + def.id))},#${ownerHistId},${ifcStr(def.name)},$,.P_SINGLEVALUE.,${ifcStr(FIELD_MEASURE[def.type])},$,$,$,$,$,$)`);
       return `#${id}`;
     });
     templateIds.push(addLine(ctx, '_psett_fields',
-      `IFCPROPERTYSETTEMPLATE(${ifcStr(ifcGuid('psett_fields'))},#${ownerHistId},${ifcStr(PSET.CustomFields)},$,.PSET_OCCURRENCEDRIVEN.,'IfcTask',(${fieldTmplRefs.join(',')}))`));
+      `IFCPROPERTYSETTEMPLATE(${ifcStr(guidOf(ctx, 'psett_fields'))},#${ownerHistId},${ifcStr(PSET.CustomFields)},$,.PSET_OCCURRENCEDRIVEN.,'IfcTask',(${fieldTmplRefs.join(',')}))`));
   }
   if (activityCodeTypes.length > 0) {
     const codeTmplRefs = activityCodeTypes.map(t => {
@@ -407,15 +438,15 @@ function writeStructure(
       const enumId = addLine(ctx, `_acte_${t.id}`,
         `IFCPROPERTYENUMERATION(${ifcStr(t.name)},(${labels}),$)`);
       const id = addLine(ctx, `_actt_${t.id}`,
-        `IFCSIMPLEPROPERTYTEMPLATE(${ifcStr(ifcGuid('actt_' + t.id))},#${ownerHistId},${ifcStr(t.name)},$,.P_ENUMERATEDVALUE.,$,$,#${enumId},$,$,$,$)`);
+        `IFCSIMPLEPROPERTYTEMPLATE(${ifcStr(guidOf(ctx, 'actt_' + t.id))},#${ownerHistId},${ifcStr(t.name)},$,.P_ENUMERATEDVALUE.,$,$,#${enumId},$,$,$,$)`);
       return `#${id}`;
     });
     templateIds.push(addLine(ctx, '_psett_codes',
-      `IFCPROPERTYSETTEMPLATE(${ifcStr(ifcGuid('psett_codes'))},#${ownerHistId},${ifcStr(PSET.ActivityCodes)},$,.PSET_OCCURRENCEDRIVEN.,'IfcTask',(${codeTmplRefs.join(',')}))`));
+      `IFCPROPERTYSETTEMPLATE(${ifcStr(guidOf(ctx, 'psett_codes'))},#${ownerHistId},${ifcStr(PSET.ActivityCodes)},$,.PSET_OCCURRENCEDRIVEN.,'IfcTask',(${codeTmplRefs.join(',')}))`));
   }
   if (templateIds.length > 0) {
     addLine(ctx, '_decl_templates',
-      `IFCRELDECLARES(${ifcStr(ifcGuid('decl_templates'))},#${ownerHistId},$,$,${projRef},(${templateIds.map(i => `#${i}`).join(',')}))`);
+      `IFCRELDECLARES(${ifcStr(guidOf(ctx, 'decl_templates'))},#${ownerHistId},$,$,${projRef},(${templateIds.map(i => `#${i}`).join(',')}))`);
   }
 
   // Waarden per taak.
@@ -431,7 +462,7 @@ function writeStructure(
         return `#${id}`;
       });
       const setId = addLine(ctx, `_pset_cf_${task.id}`,
-        `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_cf_' + task.id))},#${ownerHistId},${ifcStr(PSET.CustomFields)},$,(${propRefs.join(',')}))`);
+        `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_cf_' + task.id))},#${ownerHistId},${ifcStr(PSET.CustomFields)},$,(${propRefs.join(',')}))`);
       relDefines(`_rel_cf_${task.id}`, ref(ctx, `task_${task.id}`), setId);
     }
 
@@ -448,7 +479,7 @@ function writeStructure(
         return `#${id}`;
       });
       const setId = addLine(ctx, `_pset_ac_${task.id}`,
-        `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_ac_' + task.id))},#${ownerHistId},${ifcStr(PSET.ActivityCodes)},$,(${propRefs.join(',')}))`);
+        `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_ac_' + task.id))},#${ownerHistId},${ifcStr(PSET.ActivityCodes)},$,(${propRefs.join(',')}))`);
       relDefines(`_rel_ac_${task.id}`, ref(ctx, `task_${task.id}`), setId);
     }
   }
@@ -472,9 +503,9 @@ function writeLibraryPool(
   const propId = addLine(ctx, '_ps_library',
     `IFCPROPERTYSINGLEVALUE('pool',$,IFCTEXT(${ifcStr(json)}),$)`);
   const setId = addLine(ctx, '_pset_library',
-    `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_library'))},#${ownerHistId},${ifcStr(PSET.Library)},$,(#${propId}))`);
+    `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_library'))},#${ownerHistId},${ifcStr(PSET.Library)},$,(#${propId}))`);
   addLine(ctx, '_rel_library',
-    `IFCRELDEFINESBYPROPERTIES(${ifcStr(ifcGuid('rel_library'))},#${ownerHistId},$,$,(${projRef}),#${setId})`);
+    `IFCRELDEFINESBYPROPERTIES(${ifcStr(guidOf(ctx, 'rel_library'))},#${ownerHistId},$,$,(${projRef}),#${setId})`);
 }
 
 /**
@@ -508,9 +539,9 @@ function emitPerTaskPsets(ctx: WriteContext, tasks: Task[], ownerHistId: number)
         `#${addLine(ctx, `_prop_${desc.name}_${task.id}_${i}`,
           `IFCPROPERTYSINGLEVALUE(${ifcStr(s.name)},$,${s.value},$)`)}`);
       const setId = addLine(ctx, `_pset_${desc.name}_${task.id}`,
-        `IFCPROPERTYSET(${ifcStr(ifcGuid(desc.psetSeed + task.id))},#${ownerHistId},${ifcStr(desc.name)},$,(${propRefs.join(',')}))`);
+        `IFCPROPERTYSET(${ifcStr(guidOf(ctx, desc.psetSeed + task.id))},#${ownerHistId},${ifcStr(desc.name)},$,(${propRefs.join(',')}))`);
       addLine(ctx, `_rel_${desc.name}_${task.id}`,
-        `IFCRELDEFINESBYPROPERTIES(${ifcStr(ifcGuid(desc.relSeed + task.id))},#${ownerHistId},$,$,(${ref(ctx, `task_${task.id}`)}),#${setId})`);
+        `IFCRELDEFINESBYPROPERTIES(${ifcStr(guidOf(ctx, desc.relSeed + task.id))},#${ownerHistId},$,$,(${ref(ctx, `task_${task.id}`)}),#${setId})`);
     }
   }
 }
@@ -535,14 +566,35 @@ function writeBaselineMeta(
   const props: number[] = [];
   props.push(addLine(ctx, '_ps_baselines_json',
     `IFCPROPERTYSINGLEVALUE('Baselines',$,IFCTEXT(${ifcStr(json)}),$)`));
+  // Bevinding B8, stap 1 — DE ONTKOPPELING, en die moet vóór de botsingscheck komen.
+  //
+  // De baseline-JSON draagt INTERNE taak-id's. De reader mapte die terug door zelf `ifcGuid(taskId)`
+  // te herberekenen en dat te vergelijken met de GlobalId's in het bestand. Daarmee was de kwaliteit
+  // van de hash semantisch dragend: een botsing gaf stille kruisbesmetting tussen baselines, en een
+  // gesuffixt GlobalId (wat `guidOf` bij een botsing uitgeeft) zou de reader nooit terugvinden.
+  //
+  // We schrijven daarom expliciet wég welk GlobalId deze writer per baseline-taak gebruikte. De
+  // reader leest die map en herberekent niets meer; de hash is dan alleen nog een naamgenerator.
+  // Alleen de taak-id's die in baselines voorkomen — de map blijft zo klein en de golden rule
+  // ("alleen schrijven wat nodig is") overeind.
+  const baselineTaskGuids: Record<string, string> = {};
+  for (const b of baselines) {
+    for (const bt of b.tasks ?? []) {
+      if (bt.taskId) baselineTaskGuids[bt.taskId] = guidOf(ctx, bt.taskId);
+    }
+  }
+  if (Object.keys(baselineTaskGuids).length > 0) {
+    props.push(addLine(ctx, '_ps_baselines_guids',
+      `IFCPROPERTYSINGLEVALUE('TaskGuids',$,IFCTEXT(${ifcStr(JSON.stringify(baselineTaskGuids))}),$)`));
+  }
   if (activeBaselineId) {
     props.push(addLine(ctx, '_ps_baselines_active',
       `IFCPROPERTYSINGLEVALUE('ActiveBaselineId',$,IFCTEXT(${ifcStr(activeBaselineId)}),$)`));
   }
   const setId = addLine(ctx, '_pset_baselines',
-    `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_baselines'))},#${ownerHistId},${ifcStr(PSET.Baselines)},$,(${props.map(i => `#${i}`).join(',')}))`);
+    `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_baselines'))},#${ownerHistId},${ifcStr(PSET.Baselines)},$,(${props.map(i => `#${i}`).join(',')}))`);
   addLine(ctx, '_rel_baselines',
-    `IFCRELDEFINESBYPROPERTIES(${ifcStr(ifcGuid('rel_baselines'))},#${ownerHistId},$,$,(#${workSchedId}),#${setId})`);
+    `IFCRELDEFINESBYPROPERTIES(${ifcStr(guidOf(ctx, 'rel_baselines'))},#${ownerHistId},$,$,(#${workSchedId}),#${setId})`);
 }
 
 /**
@@ -562,9 +614,9 @@ function writeSchedulingOptionsMeta(
   const propId = addLine(ctx, '_ps_schedopts',
     `IFCPROPERTYSINGLEVALUE('SchedulingOptions',$,IFCTEXT(${ifcStr(json)}),$)`);
   const setId = addLine(ctx, '_pset_schedopts',
-    `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_schedopts'))},#${ownerHistId},${ifcStr(PSET.SchedulingOptions)},$,(#${propId}))`);
+    `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_schedopts'))},#${ownerHistId},${ifcStr(PSET.SchedulingOptions)},$,(#${propId}))`);
   addLine(ctx, '_rel_schedopts',
-    `IFCRELDEFINESBYPROPERTIES(${ifcStr(ifcGuid('rel_schedopts'))},#${ownerHistId},$,$,(#${workSchedId}),#${setId})`);
+    `IFCRELDEFINESBYPROPERTIES(${ifcStr(guidOf(ctx, 'rel_schedopts'))},#${ownerHistId},$,$,(#${workSchedId}),#${setId})`);
 }
 
 /** Fase 2.8b (§7.1) — `IfcWorkCalendar.PredefinedType` uit `calendar.shift`. CONVENTIE: buildingSMART
@@ -624,7 +676,7 @@ function writeCalendar(ctx: WriteContext, cal: WorkCalendar, ownerHistId: number
   // ObjectType (arg 4): alleen een label bij USERDEFINED-ploeg; anders `$` (byte-identiek).
   const objectType = cal.shift === 'USERDEFINED' ? ifcStr('USERDEFINED') : '$';
   return addLine(ctx, key,
-    `IFCWORKCALENDAR(${ifcStr(ifcGuid(cal.id))},#${ownerHistId},${ifcStr(cal.name)},${ifcStr(cal.description)},${objectType},(#${workTimeId}),${exceptStr},${shiftToPredefinedType(cal.shift)})`);
+    `IFCWORKCALENDAR(${ifcStr(guidOf(ctx, cal.id))},#${ownerHistId},${ifcStr(cal.name)},${ifcStr(cal.description)},${objectType},(#${workTimeId}),${exceptStr},${shiftToPredefinedType(cal.shift)})`);
 }
 
 /**
@@ -664,9 +716,9 @@ function writeCalendarGenerationMeta(
       `IFCPROPERTYSINGLEVALUE('LibraryOrigin',$,IFCTEXT(${ifcStr(JSON.stringify(cal.libraryOrigin))}),$)`));
   }
   const setId = addLine(ctx, `_pset_opscal_${cal.id}`,
-    `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_opscal_' + cal.id))},#${ownerHistId},${ifcStr(PSET.Calendar)},$,(${props.map(i => `#${i}`).join(',')}))`);
+    `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_opscal_' + cal.id))},#${ownerHistId},${ifcStr(PSET.Calendar)},$,(${props.map(i => `#${i}`).join(',')}))`);
   addLine(ctx, `_rel_opscal_${cal.id}`,
-    `IFCRELDEFINESBYPROPERTIES(${ifcStr(ifcGuid('rel_opscal_' + cal.id))},#${ownerHistId},$,$,(#${calStepId}),#${setId})`);
+    `IFCRELDEFINESBYPROPERTIES(${ifcStr(guidOf(ctx, 'rel_opscal_' + cal.id))},#${ownerHistId},$,$,(#${calStepId}),#${setId})`);
 }
 
 /**
@@ -698,7 +750,7 @@ function writeCalendarLibrary(
       .filter(r => r !== '#0');
     if (resRefs.length > 0) {
       addLine(ctx, `resctrl_${cal.id}`,
-        `IFCRELASSIGNSTOCONTROL(${ifcStr(ifcGuid('resctrl_' + cal.id))},#${ownerHistId},$,$,(${resRefs.join(',')}),$,#${calStepId})`);
+        `IFCRELASSIGNSTOCONTROL(${ifcStr(guidOf(ctx, 'resctrl_' + cal.id))},#${ownerHistId},$,$,(${resRefs.join(',')}),$,#${calStepId})`);
     }
 
     const taskRefs = tasks
@@ -707,7 +759,7 @@ function writeCalendarLibrary(
       .filter(r => r !== '#0');
     if (taskRefs.length > 0) {
       addLine(ctx, `taskctrl_${cal.id}`,
-        `IFCRELASSIGNSTOCONTROL(${ifcStr(ifcGuid('taskctrl_' + cal.id))},#${ownerHistId},$,$,(${taskRefs.join(',')}),$,#${calStepId})`);
+        `IFCRELASSIGNSTOCONTROL(${ifcStr(guidOf(ctx, 'taskctrl_' + cal.id))},#${ownerHistId},$,$,(${taskRefs.join(',')}),$,#${calStepId})`);
     }
   }
 }
@@ -752,7 +804,7 @@ function writeTask(
     `IFCTASKTIME(${IFC_TASKTIME_SLOTS.map(s => s.write(ttCtx)).join(',')})`);
 
   const taskCtx: TaskWriteCtx = {
-    task, ownerHistId, guidArg: ifcStr(ifcGuid(task.id)), taskTimeId,
+    task, ownerHistId, guidArg: ifcStr(guidOf(ctx, task.id)), taskTimeId,
   };
   addLine(ctx, `task_${task.id}`,
     `IFCTASK(${IFC_TASK_SLOTS.map(s => s.write(taskCtx)).join(',')})`);
@@ -767,7 +819,7 @@ function writeWBSNesting(ctx: WriteContext, tasks: Task[], ownerHistId: number):
       .join(',');
     if (childRefs) {
       addLine(ctx, `nest_${task.id}`,
-        `IFCRELNESTS(${ifcStr(ifcGuid('nest_' + task.id))},#${ownerHistId},${ifcStr('WBS ' + task.name)},$,${ref(ctx, `task_${task.id}`)},( ${childRefs}))`);
+        `IFCRELNESTS(${ifcStr(guidOf(ctx, 'nest_' + task.id))},#${ownerHistId},${ifcStr('WBS ' + task.name)},$,${ref(ctx, `task_${task.id}`)},( ${childRefs}))`);
     }
   }
 }
@@ -804,14 +856,14 @@ function writeSequence(ctx: WriteContext, seq: Sequence, ownerHistId: number): v
   }
 
   addLine(ctx, `seq_${seq.id}`,
-    `IFCRELSEQUENCE(${ifcStr(ifcGuid(seq.id))},#${ownerHistId},$,$,${ref(ctx, `task_${seq.predecessorId}`)},${ref(ctx, `task_${seq.successorId}`)},${lagRef},.${seq.type}.,$)`);
+    `IFCRELSEQUENCE(${ifcStr(guidOf(ctx, seq.id))},#${ownerHistId},$,$,${ref(ctx, `task_${seq.predecessorId}`)},${ref(ctx, `task_${seq.successorId}`)},${lagRef},.${seq.type}.,$)`);
 }
 
 function writeResource(ctx: WriteContext, res: Resource, ownerHistId: number): void {
   // Entiteitnaam uit de gedeelde RESOURCE_TYPE_TO_IFC-map (reader leidt de inverse eruit af).
   // Fallback op MATERIAL is byte-identiek aan de vroegere switch-`default`.
   const entityName = RESOURCE_TYPE_TO_IFC[res.type] ?? 'IFCCONSTRUCTIONMATERIALRESOURCE';
-  const entity = `${entityName}(${ifcStr(ifcGuid(res.id))},#${ownerHistId},${ifcStr(res.name)},${ifcStr(res.description)},$,$,$,$,.USERDEFINED.)`;
+  const entity = `${entityName}(${ifcStr(guidOf(ctx, res.id))},#${ownerHistId},${ifcStr(res.name)},${ifcStr(res.description)},$,$,$,$,.USERDEFINED.)`;
   addLine(ctx, `res_${res.id}`, entity);
 }
 
@@ -853,7 +905,7 @@ function writeResourceMeta(ctx: WriteContext, resources: Resource[], ownerHistId
       // Vangnet naast IFCRELNESTS (writeCrewNesting): de eigen reader hoeft nooit
       // afhankelijk te zijn van relatie-richting-interpretatie door andere IFC-tools.
       const id = addLine(ctx, `_respg_${res.id}`,
-        `IFCPROPERTYSINGLEVALUE('ParentGuid',$,IFCTEXT(${ifcStr(ifcGuid(res.parentId))}),$)`);
+        `IFCPROPERTYSINGLEVALUE('ParentGuid',$,IFCTEXT(${ifcStr(guidOf(ctx, res.parentId))}),$)`);
       props.push(`#${id}`);
     }
     if (res.libraryOrigin) {
@@ -863,9 +915,9 @@ function writeResourceMeta(ctx: WriteContext, resources: Resource[], ownerHistId
     }
     if (props.length === 0) continue;
     const setId = addLine(ctx, `_pset_res_${res.id}`,
-      `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_res_' + res.id))},#${ownerHistId},${ifcStr(PSET.Resource)},$,(${props.join(',')}))`);
+      `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_res_' + res.id))},#${ownerHistId},${ifcStr(PSET.Resource)},$,(${props.join(',')}))`);
     addLine(ctx, `_rel_res_${res.id}`,
-      `IFCRELDEFINESBYPROPERTIES(${ifcStr(ifcGuid('rel_res_' + res.id))},#${ownerHistId},$,$,(${ref(ctx, `res_${res.id}`)}),#${setId})`);
+      `IFCRELDEFINESBYPROPERTIES(${ifcStr(guidOf(ctx, 'rel_res_' + res.id))},#${ownerHistId},$,$,(${ref(ctx, `res_${res.id}`)}),#${setId})`);
   }
 }
 
@@ -883,7 +935,7 @@ function writeCrewNesting(ctx: WriteContext, resources: Resource[], ownerHistId:
       .filter(r => r !== '#0');
     if (memberRefs.length === 0) continue;
     addLine(ctx, `nest_res_${crew.id}`,
-      `IFCRELNESTS(${ifcStr(ifcGuid('nest_res_' + crew.id))},#${ownerHistId},${ifcStr('Ploeg ' + crew.name)},$,${ref(ctx, `res_${crew.id}`)},(${memberRefs.join(',')}))`);
+      `IFCRELNESTS(${ifcStr(guidOf(ctx, 'nest_res_' + crew.id))},#${ownerHistId},${ifcStr('Ploeg ' + crew.name)},$,${ref(ctx, `res_${crew.id}`)},(${memberRefs.join(',')}))`);
   }
 }
 
@@ -901,7 +953,7 @@ function writeAssignments(ctx: WriteContext, assignments: ResourceAssignment[], 
     const taskRef = ref(ctx, `task_${taskId}`);
     if (taskRef === '#0') continue;
     addLine(ctx, `assign_${taskId}`,
-      `IFCRELASSIGNSTOPROCESS(${ifcStr(ifcGuid('assign_' + taskId))},#${ownerHistId},$,$,(${resRefs.join(',')}),$,${taskRef},$)`);
+      `IFCRELASSIGNSTOPROCESS(${ifcStr(guidOf(ctx, 'assign_' + taskId))},#${ownerHistId},$,$,(${resRefs.join(',')}),$,${taskRef},$)`);
   }
 }
 
@@ -916,7 +968,7 @@ function writeAssignments(ctx: WriteContext, assignments: ResourceAssignment[], 
  * propertynaam corrumpeerde meerdere assignments van DEZELFDE resource op één taak (bv.
  * R×1(UNIFORM) + R×0.5(BELL)) — de reader dedupte op propertynaam → last-wins. Het
  * `#<volgnummer>`-achtervoegsel (0-based positie binnen de assignmentlijst van de taak) maakt
- * elke property uniek. `ifcGuid(...)` produceert nooit een `#`, dus het scheidingsteken is
+ * elke property uniek. `guidOf(ctx, ...)` produceert nooit een `#`, dus het scheidingsteken is
  * eenduidig. De reader leest ZOWEL dit nieuwe formaat (`GUID#N`) als het oude kale-GUID-formaat
  * (legacy bestanden, §7.4). Alleen geschreven wanneer de taak minstens één assignment heeft
  * (golden rule §7.7).
@@ -936,7 +988,7 @@ function writeAssignmentMeta(
     const list = byTask.get(task.id);
     if (!list || list.length === 0) continue;
     const props = list.map((a, index) => {
-      const resGuid = ifcGuid(a.resourceId); // zelfde GUID als writeResource gebruikte
+      const resGuid = guidOf(ctx, a.resourceId); // zelfde GUID als writeResource gebruikte
       const propName = `${resGuid}#${index}`; // uniek per assignment (M3)
       const val = `${a.unitsPerDay}|${a.curve ?? 'UNIFORM'}`;
       const propId = addLine(ctx, `_asgn_${task.id}_${a.id}`,
@@ -944,8 +996,8 @@ function writeAssignmentMeta(
       return `#${propId}`;
     });
     const setId = addLine(ctx, `_pset_asgn_${task.id}`,
-      `IFCPROPERTYSET(${ifcStr(ifcGuid('pset_asgn_' + task.id))},#${ownerHistId},${ifcStr(PSET.Assignments)},$,(${props.join(',')}))`);
+      `IFCPROPERTYSET(${ifcStr(guidOf(ctx, 'pset_asgn_' + task.id))},#${ownerHistId},${ifcStr(PSET.Assignments)},$,(${props.join(',')}))`);
     addLine(ctx, `_rel_asgn_${task.id}`,
-      `IFCRELDEFINESBYPROPERTIES(${ifcStr(ifcGuid('rel_asgn_' + task.id))},#${ownerHistId},$,$,(${ref(ctx, `task_${task.id}`)}),#${setId})`);
+      `IFCRELDEFINESBYPROPERTIES(${ifcStr(guidOf(ctx, 'rel_asgn_' + task.id))},#${ownerHistId},$,$,(${ref(ctx, `task_${task.id}`)}),#${setId})`);
   }
 }

--- a/tests/planning/check-ifc-roundtrip.ts
+++ b/tests/planning/check-ifc-roundtrip.ts
@@ -679,6 +679,59 @@ const rt2 = readIFC(writeIFC(rt1));
 }
 
 // ════════════════════════════════════════════════════════════════════════════════════════════════
+// (5) B8 — GlobalId-uitgifte: uniciteit, en de ONTKOPPELING van de baseline-remap.
+//
+// `ifcGuid` is een 32-bits hash, geen UUID. Twee dingen zijn nu geborgd, en de volgorde waarin ze
+// zijn aangepakt is wezenlijk: eerst de ontkoppeling (de writer schrijft wég welk GlobalId hij per
+// baseline-taak gebruikte), pas daarna de botsingscheck. Andersom zou een gesuffixt GlobalId de
+// remap breken, omdat de reader de hash dan nog zelf herberekende.
+{
+  const ifc = writeIFC(fixture);
+
+  // (5a) Elk ENTITY-GlobalId komt precies één keer voor. Let op de ankering op `#N=`: een naïeve
+  //      scan op `IFC…('…')` telt ook `IFCTEXT('<guid>')` mee, en dat zijn juist de bedoelde
+  //      VERWIJZINGEN naar een GlobalId (ParentGuid, en de resource-GUID als property-naam van een
+  //      toewijzing). Die horen te herhalen; entity-id's niet.
+  const entityGuids = [...ifc.matchAll(/^#\d+=IFC[A-Z]+\('([0-9A-Za-z_$]{22})'/gm)].map(m => m[1]);
+  const dupes = entityGuids.filter((g, i) => entityGuids.indexOf(g) !== i);
+  assert(entityGuids.length > 20, `verwachtte een flink aantal entity-GlobalIds — kreeg ${entityGuids.length}`);
+  assert(dupes.length === 0, `entity-GlobalIds moeten uniek zijn — dubbel: ${[...new Set(dupes)].join(', ')}`);
+
+  // (5b) De writer schrijft de taak→GlobalId-map expliciet weg, zodat de reader niets hoeft te
+  //      herberekenen.
+  assert(ifc.includes("'TaskGuids'"), 'writeBaselineMeta moet een TaskGuids-map schrijven zolang er baselines zijn');
+
+  const baseRt = readIFC(ifc);
+  const bt0 = baseRt.baselines![0].tasks[0];
+  assert(baseRt.tasks.some(t => t.id === bt0.taskId),
+    'basisgeval: de baseline-taak moet normaal op een bestaande taak worden geremapt');
+
+  // (5c) En de reader GEBRUIKT die map. Bewijs: wijs in de map de eerste baseline-taak naar het
+  //      GlobalId van een ÁNDERE taak. Herberekende de reader nog zelf, dan verandert er niets;
+  //      volgt hij de map, dan landt de baseline-taak op die andere taak.
+  const other = baseRt.tasks.find(t => t.id !== bt0.taskId)!;
+  const otherLine = ifc.split('\n').find(l => l.includes('=IFCTASK(') && l.includes(`'${other.name}'`))!;
+  const otherGuid = /=IFCTASK\('([0-9A-Za-z_$]{22})'/.exec(otherLine)![1];
+  const mapLine = ifc.split('\n').find(l => l.includes("'TaskGuids'"))!;
+  const origGuid = /IFCTEXT\('.*?:.*?([0-9A-Za-z_$]{22})/.exec(mapLine)?.[1];
+  assert(!!origGuid, 'kon het eerste GlobalId in de TaskGuids-map niet uitlezen');
+  const tampered = ifc.replace(mapLine, mapLine.replace(origGuid!, otherGuid));
+  const rtTampered = readIFC(tampered);
+  // NB: `readIFC` genereert per leesbeurt NIEUWE taak-id's, dus vergelijken met een id uit een
+  //     eerdere leesbeurt kan niet — we identificeren de doeltaak op naam binnen dezelfde beurt.
+  const otherInTampered = rtTampered.tasks.find(t => t.name === other.name)!;
+  assert(rtTampered.baselines![0].tasks.some(bt => bt.taskId === otherInTampered.id),
+    'de reader moet de expliciete TaskGuids-map volgen, niet de hash herberekenen (B8-ontkoppeling)');
+
+  // (5d) Terugval voor bestanden van vóór deze wijziging: haal de map weg en de remap moet nog
+  //      steeds werken via de herberekende hash.
+  const legacy = ifc.split('\n').filter(l => !l.includes("'TaskGuids'")).join('\n');
+  const rtLegacyGuids = readIFC(legacy);
+  assert(rtLegacyGuids.tasks.some(t => t.id === rtLegacyGuids.baselines![0].tasks[0].taskId),
+    'zonder TaskGuids-map (oud bestand) moet de remap terugvallen op het herberekenen van de hash');
+}
+
+// ════════════════════════════════════════════════════════════════════════════════════════════════
 if (fails === 0) {
   console.log(`OK  ifc-roundtrip: alle checks groen (${checks})`);
   process.exit(0);


### PR DESCRIPTION
Item 29 uit fase "structureel" (`docs/onderhoudbaarheid/README.md` §5, bevinding B8).

## Het probleem

`ifcGuid` is een 32-bits hash — geen UUID, geen conforme IFC-GUID. Over 20.000 realistische id's zijn geen botsingen gemeten, dus in de praktijk hield het stand. Maar de functie was **semantisch dragend**: `extractBaselines` mapte baseline-taakId's terug door de hash zélf te herberekenen. Een botsing gaf daarmee stille kruisbesmetting tussen baselines, en er was geen enkele detectie.

## De volgorde ís de fix

Het rapport is er expliciet over, en dat blijkt te kloppen.

**Stap 1 — de ontkoppeling.** `writeBaselineMeta` schrijft nu een expliciete `TaskGuids`-map (interne taak-id → het GlobalId dat deze writer daadwerkelijk uitgaf) naast de baseline-JSON. De reader gebruikt die map en herberekent niets meer. Ontbreekt hij, dan valt hij terug op de oude weg — bestanden van vóór deze versie blijven werken. Alleen taak-id's die in baselines voorkomen gaan de map in (golden rule: alleen schrijven wat nodig is).

**Stap 2 — pas dáárna de botsingscheck.** Alle 44 GUID-uitgiftes in de writer lopen nu via één `guidOf(ctx, seed)`: memoiseert per seed, houdt een `Set` van uitgegeven GlobalIds bij, en zoekt bij een botsing deterministisch door met een gesuffixte seed. Zonder botsing is de uitkomst **byte-identiek** aan `ifcGuid(seed)` — bestaande bestanden veranderen niet.

Andersom had niet gekund: een gesuffixt GlobalId zou de baseline-remap breken zolang de reader de hash nog zelf herberekende.

## Verificatie

Vier nieuwe checks in `check-ifc-roundtrip.ts` (19 → 26), elk met een negatieve controle:

| sabotage | resultaat |
|---|---|
| reader negeert de map weer | ontkoppelingscheck valt om |
| writer schrijft de map niet | twee checks vallen om |
| **álle seeds laten botsen** | uniciteitscheck blijft **groen** (`guidOf` suffixt ze netjes uit elkaar) en precies de legacy-terugval valt om |

Die derde is de interessantste: hij demonstreert de faalmodus die het rapport voorspelde. Met alle seeds botsend blijven de GlobalIds uniek — de botsingscheck werkt — en breekt uitsluitend het pad waar de reader nog zelf rekent. Dat is exact waarom stap 1 vóór stap 2 moest.

`npm run verify` groen: alle acht poorten, roundtrip 26/26, planning 434/434.

## Twee dingen die ik onderweg fout had

Allebei in de test, niet in de code — maar het scheelde weinig of ik had ze als "bevinding" gerapporteerd:

- Mijn eerste uniciteitsscan telde ook `IFCTEXT('<guid>')` mee. Dat zijn juist de **bedoelde verwijzingen** naar een GlobalId (`ParentGuid`, en de resource-GUID als property-naam van een toewijzing) — die hóren te herhalen. De scan is nu geankerd op `#N=IFC…`.
- Ik vergeleek taak-id's tussen twee `readIFC`-beurten, terwijl die per beurt opnieuw gegenereerd worden. Dat gaat nu op naam binnen één beurt.

---
_Generated by [Claude Code](https://claude.ai/code/session_015yaZ7E5SSxM4kHpBwApi9R)_