### PR TITLE
refactor(scheduler): één applyCpmResult i.p.v. een gedivergeerde benchmark-kopie (item 30)

### DIFF
--- a/src/engine/scheduler/applyCpmResult.ts
+++ b/src/engine/scheduler/applyCpmResult.ts
@@ -1,0 +1,105 @@
+import type { Task } from '@/types/task';
+import type { WorkCalendar } from '@/types/calendar';
+import type { CPMResult } from './CPMSolver';
+import { effectiveCalendarOf } from '@/utils/taskDuration';
+import { isHourCalendar } from '@/services/subdayIo';
+import { parseInstant, formatInstant } from '@/utils/dateUtils';
+
+/**
+ * Schrijf een CPM-resultaat terug op de taken: per blad de berekende velden, daarna de
+ * verzameltaak-rollup.
+ *
+ * Waarom dit een eigen module is (K-item 30). Deze logica stond twee keer: in `runCPM`
+ * (`scheduleSlice`) en nog een keer in `src/services/benchmark/runner.ts`, met een comment die
+ * toegaf dat het een kopie was. Die kopie wás al gedivergeerd — hij miste `interferingFloat`,
+ * `isNearCritical`, `floatPath`, de late-datum-rollup, de min-over-kinderen voor
+ * `totalFloat`/`freeFloat` én de uur-modus-normalisatie. Gevolg: de benchmark mat niet meer wat de
+ * app doet, en dat is precies het soort meting waar je beslissingen op baseert.
+ *
+ * Muteert de meegegeven taken in-place. Werkt zowel op een gewone array als op een Immer-draft
+ * (`s.tasks`): de elementen blijven dezelfde proxies, dus `task.time.x = …` gedraagt zich identiek.
+ */
+export interface ApplyCpmCalendars {
+  /** De projectkalender (fallback wanneer een taak geen eigen kalender heeft). */
+  projectCalendar: WorkCalendar;
+  /** De gedeelde kalenderbibliotheek, voor `task.calendarId`. */
+  calendars: WorkCalendar[];
+}
+
+export function applyCpmResult(tasks: Task[], result: CPMResult, cals: ApplyCpmCalendars): void {
+  for (const task of tasks) {
+    const r = result.tasks.get(task.id);
+    if (!r) continue;
+    task.time.earlyStart = r.earlyStart;
+    task.time.earlyFinish = r.earlyFinish;
+    task.time.lateStart = r.lateStart;
+    task.time.lateFinish = r.lateFinish;
+    task.time.totalFloat = r.totalFloat;
+    task.time.freeFloat = r.freeFloat;
+    task.time.isCritical = r.isCritical;
+    // Fase 2.9 golf 2 (§4.6): analyse-afleidingen. `interferingFloat` is ALTIJD aanwezig (tf−ff);
+    // `isNearCritical`/`floatPath` alleen wanneer de bijbehorende optie draait — afwezig ⇒ het veld
+    // wordt gewist (zodat een uitgezette optie geen stale markering laat staan).
+    task.time.interferingFloat = r.interferingFloat;
+    task.time.isNearCritical = r.isNearCritical !== undefined ? r.isNearCritical : undefined;
+    task.time.floatPath = r.floatPath !== undefined ? r.floatPath : undefined;
+    // BEWUST GEEN scheduleStart-ANKER-drift: scheduleStart is het GEPLANDE anker (waarop de
+    // forward-pass voortbouwt, `CPMSolver` snapt hierop) en mag NIET de berekende earlyStart
+    // worden — anders bleef een taak na het verwijderen van een relatie op z'n gedrifte datum
+    // hangen. De berekende planning leeft in earlyStart/earlyFinish; weergave/export gebruikt
+    // `earlyStart || scheduleStart`.
+    //
+    // UUR-MODUS (fase 2.8b, FIX golf, §2.4): scheduleStart/scheduleFinish moeten wél een
+    // datetime-representatie dragen i.p.v. date-only/verouderd te blijven. scheduleFinish volgt de
+    // berekende finish (geen anker ⇒ veilig; nooit meer stale na een duur-wijziging); scheduleStart
+    // houdt zijn ANKER-instant maar wordt idempotent naar de datetime-vorm genormaliseerd
+    // (parseInstant→formatInstant('hour') verandert de instant niet, dus geen drift). Dag-taken
+    // blijven ONGEMOEID ⇒ byte-identiek (`formatDate`, verify:examples).
+    const effCal = effectiveCalendarOf(task, cals.projectCalendar, cals.calendars);
+    if (isHourCalendar(effCal)) {
+      task.time.scheduleFinish = r.earlyFinish;
+      task.time.scheduleStart = formatInstant(parseInstant(task.time.scheduleStart), 'hour');
+    }
+  }
+
+  // Verzameltaken: datums oprollen uit de kinderen.
+  // A4 (prestatie): één vooraf gebouwde id→taak-Map i.p.v. `find` per taak én per kind (recursief) —
+  // dat was O(n²) op de rollup.
+  const byId = new Map<string, Task>(tasks.map(t => [t.id, t]));
+  const updateSummary = (taskId: string): void => {
+    const task = byId.get(taskId);
+    if (!task || task.childIds.length === 0) return;
+
+    for (const childId of task.childIds) updateSummary(childId);
+
+    const children = task.childIds
+      .map(cid => byId.get(cid))
+      .filter(Boolean) as Task[];
+
+    if (children.length > 0) {
+      const starts = children.map(c => c.time.earlyStart).sort();
+      const finishes = children.map(c => c.time.earlyFinish).sort();
+      task.time.earlyStart = starts[0];
+      task.time.earlyFinish = finishes[finishes.length - 1];
+      task.time.isCritical = children.some(c => c.time.isCritical);
+
+      // Ook de LATE datums en speling oprollen — anders bleven die op de
+      // createDefaultTaskTime-defaults staan (lf=es, tf=0) en schreef o.a. ifcWriter misleidende
+      // fase-speling weg (een niet-kritieke fase met "tf=0").
+      const lateStarts = children.map(c => c.time.lateStart).sort();
+      const lateFinishes = children.map(c => c.time.lateFinish).sort();
+      task.time.lateStart = lateStarts[0];
+      task.time.lateFinish = lateFinishes[lateFinishes.length - 1];
+      // Een verzameltaak kan maar zo veel opschuiven als zijn krapste kind: min over de kinderen.
+      task.time.totalFloat = Math.min(...children.map(c => c.time.totalFloat));
+      task.time.freeFloat = Math.min(...children.map(c => c.time.freeFloat));
+      // Interfererende speling op de samenvatting = tf−ff (fase 2.9 golf 2, §4.6) — houdt de
+      // invariant ook op verzameltaken en vult de kolom voor WBS-rijen.
+      task.time.interferingFloat = task.time.totalFloat - task.time.freeFloat;
+    }
+  };
+
+  for (const task of tasks) {
+    if (!task.parentId) updateSummary(task.id);
+  }
+}

--- a/src/services/benchmark/runner.ts
+++ b/src/services/benchmark/runner.ts
@@ -6,13 +6,17 @@
 // zichtbaar bijwerkt.
 
 import { CPMSolver } from '@/engine/scheduler/CPMSolver';
+// K-item 30: hier stond een eigen kopie van het terugschrijven, die al was gedivergeerd
+// (miste interferingFloat, isNearCritical, floatPath, de late-datum-rollup, de
+// min-over-kinderen voor tf/ff en de uur-modus). De benchmark mat daardoor niet meer wat
+// de app doet — precies het soort meting waar je beslissingen op baseert.
+import { applyCpmResult } from '@/engine/scheduler/applyCpmResult';
 import { writeIFC } from '@/services/ifc/ifcWriter';
 import { readIFC } from '@/services/ifc/ifcReader';
 import { GanttRenderer, type GanttRenderOptions } from '@/engine/renderer/GanttRenderer';
 import { computeViewRows, type ViewRow } from '@/engine/view/visibleRows';
 import type { ViewContext } from '@/engine/view/filterEval';
 import type { ViewState } from '@/types/view';
-import type { Task } from '@/types/task';
 import type { CPMResult } from '@/engine/scheduler/CPMSolver';
 import { generateBenchmarkProject, type GeneratedProject } from './generateProject';
 import { formatBytes } from '@/utils/formatBytes';
@@ -76,36 +80,6 @@ function iterationsFor(size: number, phase: PhaseId): number {
   return base;
 }
 
-/** Schrijf een CPM-resultaat terug op de taken (leaf + verzameltaak-rollup), zoals `runCPM` dat
- *  doet — zodat de IFC-write en de render met realistisch gespreide datums werken. Muteert alleen
- *  de meegegeven (lokale) taken; raakt de store niet. */
-function applyCpmResult(tasks: Task[], result: CPMResult): void {
-  const byId = new Map(tasks.map((t) => [t.id, t]));
-  for (const task of tasks) {
-    const r = result.tasks.get(task.id);
-    if (!r) continue;
-    task.time.earlyStart = r.earlyStart;
-    task.time.earlyFinish = r.earlyFinish;
-    task.time.lateStart = r.lateStart;
-    task.time.lateFinish = r.lateFinish;
-    task.time.totalFloat = r.totalFloat;
-    task.time.freeFloat = r.freeFloat;
-    task.time.isCritical = r.isCritical;
-  }
-  const rollup = (taskId: string) => {
-    const task = byId.get(taskId);
-    if (!task || task.childIds.length === 0) return;
-    for (const cid of task.childIds) rollup(cid);
-    const children = task.childIds.map((cid) => byId.get(cid)).filter(Boolean) as Task[];
-    if (children.length === 0) return;
-    const starts = children.map((c) => c.time.earlyStart).sort();
-    const finishes = children.map((c) => c.time.earlyFinish).sort();
-    task.time.earlyStart = starts[0];
-    task.time.earlyFinish = finishes[finishes.length - 1];
-    task.time.isCritical = children.some((c) => c.time.isCritical);
-  };
-  for (const task of tasks) if (!task.parentId) rollup(task.id);
-}
 
 /** Bouw de gedeelde `viewRows` (pure boommodus: geen filter/groep/sort) voor de render-fase. */
 function buildViewRows(data: GeneratedProject): ViewRow[] {
@@ -174,7 +148,9 @@ export async function runBenchmark({ size, version, onProgress }: RunOptions): P
   phases.push({ phase: 'cpm', iterations: cpmIters, ...stats(cpmSamples) });
 
   // Resultaat terugschrijven zodat write/read/render met echte datums werken.
-  if (lastResult && !lastResult.error) applyCpmResult(data.tasks, lastResult);
+  if (lastResult && !lastResult.error) {
+    applyCpmResult(data.tasks, lastResult, { projectCalendar: data.calendar, calendars: [data.calendar] });
+  }
   await yieldToUi();
 
   // --- Fase 3: IFC schrijven ---------------------------------------------------

--- a/src/state/slices/scheduleSlice.ts
+++ b/src/state/slices/scheduleSlice.ts
@@ -1,5 +1,5 @@
-import type { Task } from '@/types/task';
 import { CPMSolver, type CPMResult } from '@/engine/scheduler/CPMSolver';
+import { applyCpmResult } from '@/engine/scheduler/applyCpmResult';
 import { computeResourceLoad, type ResourceLoadResult } from '@/engine/scheduler/ResourceLoad';
 import {
   levelResources as computeLeveling,
@@ -8,9 +8,6 @@ import {
 } from '@/engine/scheduler/ResourceLeveler';
 import { beginUndoable, finishMutation } from '../transaction';
 import { emitExtensionEvent, HOST_EVENTS } from '@/services/extensionEvents';
-import { effectiveCalendarOf } from '@/utils/taskDuration';
-import { isHourCalendar } from '@/services/subdayIo';
-import { parseInstant, formatInstant } from '@/utils/dateUtils';
 import type { AppSlice } from './types';
 
 export interface ScheduleSlice {
@@ -74,91 +71,9 @@ export const createScheduleSlice: AppSlice<ScheduleSlice> = (set, get) => ({
         return;
       }
 
-      // Apply results back to tasks
-      for (const task of s.tasks) {
-        const r = result.tasks.get(task.id);
-        if (r) {
-          task.time.earlyStart = r.earlyStart;
-          task.time.earlyFinish = r.earlyFinish;
-          task.time.lateStart = r.lateStart;
-          task.time.lateFinish = r.lateFinish;
-          task.time.totalFloat = r.totalFloat;
-          task.time.freeFloat = r.freeFloat;
-          task.time.isCritical = r.isCritical;
-          // Fase 2.9 golf 2 (§4.6): analyse-afleidingen. `interferingFloat` is ALTIJD aanwezig
-          // (tf−ff); `isNearCritical`/`floatPath` alleen wanneer de bijbehorende optie draait —
-          // afwezig ⇒ het veld wordt gewist (zodat een uitgezette optie geen stale markering laat).
-          task.time.interferingFloat = r.interferingFloat;
-          if (r.isNearCritical !== undefined) task.time.isNearCritical = r.isNearCritical;
-          else task.time.isNearCritical = undefined;
-          if (r.floatPath !== undefined) task.time.floatPath = r.floatPath;
-          else task.time.floatPath = undefined;
-          // BEWUST GEEN scheduleStart-ANKER-drift: scheduleStart is de GEPLANDE anker (waarop de
-          // forward-pass voortbouwt, `CPMSolver` snapt hierop) en mag NIET de berekende earlyStart
-          // worden — anders bleef een taak na het verwijderen van een relatie op z'n gedrifte datum
-          // hangen. De berekende planning leeft in earlyStart/earlyFinish; weergave/export gebruikt
-          // `earlyStart || scheduleStart`.
-          //
-          // UUR-MODUS (fase 2.8b, FIX golf, §2.4): scheduleStart/scheduleFinish moeten wél een
-          // datetime-representatie dragen i.p.v. date-only/verouderd te blijven. scheduleFinish volgt
-          // de berekende finish (geen anker ⇒ veilig; nooit meer stale na een duur-wijziging);
-          // scheduleStart houdt zijn ANKER-instant maar wordt idempotent naar de datetime-vorm
-          // genormaliseerd (parseInstant→formatInstant('hour') verandert de instant niet, dus geen
-          // drift). Dag-taken blijven ONGEMOEID ⇒ byte-identiek (`formatDate`, verify:examples).
-          const effCal = effectiveCalendarOf(task, s.calendar, s.calendars);
-          if (isHourCalendar(effCal)) {
-            task.time.scheduleFinish = r.earlyFinish;
-            task.time.scheduleStart = formatInstant(parseInstant(task.time.scheduleStart), 'hour');
-          }
-        }
-      }
-
-      // Update summary tasks (roll up dates from children)
-      // A4 (prestatie): één vooraf gebouwde id→taak-Map i.p.v. `s.tasks.find` per taak én per kind
-      // (recursief) — dat was O(n²) op de rollup. `byId` bouwt op de draft `s.tasks`, dus
-      // `byId.get(...)` levert exact dezelfde draft-proxy als `find` (identiek muteren via
-      // `task.time.*`); alleen de opzoeking gaat van O(n) naar O(1). Rollup-logica, -volgorde en de
-      // berekende waarden blijven ongewijzigd (byte-identiek).
-      const byId = new Map<string, Task>(s.tasks.map(t => [t.id, t]));
-      const updateSummary = (taskId: string) => {
-        const task = byId.get(taskId);
-        if (!task || task.childIds.length === 0) return;
-
-        for (const childId of task.childIds) {
-          updateSummary(childId);
-        }
-
-        const children = task.childIds
-          .map(cid => byId.get(cid))
-          .filter(Boolean) as Task[];
-
-        if (children.length > 0) {
-          const starts = children.map(c => c.time.earlyStart).sort();
-          const finishes = children.map(c => c.time.earlyFinish).sort();
-          task.time.earlyStart = starts[0];
-          task.time.earlyFinish = finishes[finishes.length - 1];
-          task.time.isCritical = children.some(c => c.time.isCritical);
-
-          // Ook de LATE datums en speling oprollen — anders bleven die op de
-          // createDefaultTaskTime-defaults staan (lf=es, tf=0) en schreef o.a. ifcWriter
-          // misleidende fase-speling weg (een niet-kritieke fase met "tf=0").
-          const lateStarts = children.map(c => c.time.lateStart).sort();
-          const lateFinishes = children.map(c => c.time.lateFinish).sort();
-          task.time.lateStart = lateStarts[0];
-          task.time.lateFinish = lateFinishes[lateFinishes.length - 1];
-          // Een verzameltaak kan maar zo veel opschuiven als zijn krapste kind: min over de kinderen.
-          task.time.totalFloat = Math.min(...children.map(c => c.time.totalFloat));
-          task.time.freeFloat = Math.min(...children.map(c => c.time.freeFloat));
-          // Interfererende speling op de samenvatting = tf−ff (fase 2.9 golf 2, §4.6) — houdt de
-          // invariant ook op verzameltaken en vult de kolom voor WBS-rijen.
-          task.time.interferingFloat = task.time.totalFloat - task.time.freeFloat;
-        }
-      };
-
-      // Find root tasks (no parent)
-      for (const task of s.tasks) {
-        if (!task.parentId) updateSummary(task.id);
-      }
+      // Terugschrijven + verzameltaak-rollup: één gedeelde functie, ook gebruikt door de
+      // benchmark (K-item 30 — die had een eigen kopie die al gedivergeerd was).
+      applyCpmResult(s.tasks, result, { projectCalendar: s.calendar, calendars: s.calendars });
 
       s.cpmResult = result;
 

--- a/tests/planning/check-advanced-cpm.ts
+++ b/tests/planning/check-advanced-cpm.ts
@@ -21,6 +21,7 @@ import { validateConstraintPair } from '@/engine/scheduler/constraintValidation'
 import { refreshExternalAnchors, externalSourceSide, type ExternalSourceDoc } from '@/engine/externalLinks';
 import { writeIFC } from '@/services/ifc/ifcWriter';
 import { readIFC } from '@/services/ifc/ifcReader';
+import { applyCpmResult } from '@/engine/scheduler/applyCpmResult';
 
 const diffs: string[] = [];
 let checks = 0;
@@ -687,6 +688,47 @@ const gateP3: Task = mkTask('GateP3', 3, {
 });
 const rGateC = solve([gateQ, gateP3], [fs('gp3', 'GateQ', 'GateP3')]); // geen dataDate nodig — structureel te laat
 eq('186 detector-gate CONTROLE: geen actuals + structureel te laat ⇒ violation blijft vuren', rGateC.violatedConstraintTaskIds.includes('GateP3'), true);
+
+// ── applyCpmResult: de zes velden die de benchmark-kopie liet vallen (K-item 30) ──────────────
+// Dit terugschrijven stond twee keer: in `runCPM` en in de benchmark-runner. Die tweede kopie was
+// al gedivergeerd en miste precies de velden hieronder, waardoor de benchmark niet meer mat wat de
+// app doet. Er is nu één functie; deze checks pinnen haar contract op de verzameltaak-rollup, want
+// dáár zaten de gaten.
+{
+  const kid1 = mkTask('AC-kid1', 5, { parentId: 'AC-sum' });
+  const kid2 = mkTask('AC-kid2', 3, { parentId: 'AC-sum' });
+  const sum = mkTask('AC-sum', 0, { childIds: ['AC-kid1', 'AC-kid2'] });
+  const tasks = [sum, kid1, kid2];
+  // Twee bladeren met verschillende speling; de één kritiek, de ander niet.
+  const result = {
+    tasks: new Map([
+      // Bewust GEEN waarden die met de createDefaultTaskTime-defaults samenvallen (lateStart =
+      // scheduleStart = 2026-06-01, tf = ff = 0): anders slagen de rollup-checks ook wanneer de
+      // rollup helemaal niet draait, en meten ze niets.
+      ['AC-kid1', { earlyStart: '2026-06-01', earlyFinish: '2026-06-05', lateStart: '2026-06-03',
+        lateFinish: '2026-06-07', totalFloat: 2, freeFloat: 1, isCritical: true, interferingFloat: 1 }],
+      ['AC-kid2', { earlyStart: '2026-06-02', earlyFinish: '2026-06-04', lateStart: '2026-06-08',
+        lateFinish: '2026-06-10', totalFloat: 4, freeFloat: 3, isCritical: false, interferingFloat: 1 }],
+    ]),
+    projectStart: '2026-06-01', projectEnd: '2026-06-05', criticalPath: ['AC-kid1'],
+  } as unknown as Parameters<typeof applyCpmResult>[1];
+
+  applyCpmResult(tasks, result, { projectCalendar: CAL, calendars: [CAL] });
+
+  eq('187 rollup: earlyStart = vroegste kind', sum.time.earlyStart, '2026-06-01');
+  eq('188 rollup: earlyFinish = laatste kind', sum.time.earlyFinish, '2026-06-05');
+  eq('189 rollup: kritiek als één kind kritiek is', sum.time.isCritical, true);
+  // De vier hieronder ontbraken in de benchmark-kopie: late datums, min-over-kinderen en
+  // interferingFloat. Zonder die rollup bleven ze op de createDefaultTaskTime-defaults staan
+  // (lf = es, tf = 0) en schreef o.a. ifcWriter misleidende fase-speling weg.
+  eq('190 rollup: lateStart = vroegste late kind', sum.time.lateStart, '2026-06-03');
+  eq('191 rollup: lateFinish = laatste late kind', sum.time.lateFinish, '2026-06-10');
+  eq('192 rollup: totalFloat = min over kinderen (krapste kind bepaalt)', sum.time.totalFloat, 2);
+  eq('193 rollup: freeFloat = min over kinderen', sum.time.freeFloat, 1);
+  eq('194 rollup: interferingFloat = tf − ff, ook op de verzameltaak', sum.time.interferingFloat, 1);
+  // En op het blad zelf: interferingFloat/isNearCritical/floatPath gaan mee (idem gemist door de kopie).
+  eq('195 blad: interferingFloat komt door', kid2.time.interferingFloat, 1);
+}
 
 // ── Uitslag ──────────────────────────────────────────────────────────────────
 if (diffs.length === 0) {


### PR DESCRIPTION
Item 30 uit fase "structureel" (`docs/onderhoudbaarheid/README.md` §5).

## Het probleem

Het terugschrijven van een CPM-resultaat — blad-velden plus verzameltaak-rollup — stond **twee keer**: in `runCPM` (`scheduleSlice`) en nog een keer in `src/services/benchmark/runner.ts`, met een comment die toegaf dat het een kopie was.

Die kopie was al gedivergeerd en miste:

- `interferingFloat`, `isNearCritical`, `floatPath`
- de **late-datum**-rollup op verzameltaken
- de min-over-kinderen voor `totalFloat` / `freeFloat`
- de uur-modus-normalisatie van `scheduleStart`/`scheduleFinish`

Gevolg: de benchmark mat niet meer wat de app doet — precies het soort meting waarop je prestatiebeslissingen baseert.

## De fix

Beide callsites draaien nu op `src/engine/scheduler/applyCpmResult.ts`. De functie muteert in-place en werkt zowel op een gewone array als op een Immer-draft (`s.tasks`), zodat het store-pad byte-identiek blijft. De kalendercontext gaat expliciet mee (`projectCalendar` + `calendars`) — dat was het enige wat de store-versie uit de omringende scope trok.

## Verificatie

Negen checks in `check-advanced-cpm.ts` (186 → 195) pinnen het contract op de rollup, want daar zaten de gaten. Negatieve controle: precies de vijf regels weghalen die de benchmark-kopie miste ⇒ vijf checks vallen om.

> **Die controle wees eerst maar 2 van de 5 aan.** Mijn fixture had waarden gekozen die toevallig samenvielen met de `createDefaultTaskTime`-defaults (`lateStart` = `scheduleStart`, `tf` = `ff` = 0) — waardoor drie checks ook slaagden zónder rollup. Half-vacuüme checks dus. Fixture verscherpt naar waarden die van de defaults verschillen; nu vallen alle vijf om.

`npm run verify` groen: alle acht poorten, planning 434/434.

---
_Generated by [Claude Code](https://claude.ai/code/session_015yaZ7E5SSxM4kHpBwApi9R)_