### PR TITLE
perf(extensies): api.data.batch — één snapshot per bulk i.p.v. één per mutatie (item 32)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -349,6 +349,17 @@ deze lijst verwijderd — wat klaar is, staat in de changelog en git-historie.
       §5.1 van het plan (undo-snapshot verbreden) is op 2026-07-20 al uitgevoerd, en anders dan het
       plan voorstelde: `project` én `calendar` zitten nu volledig in de snapshot.
 
+### Klein — bulk-mutaties: tweede kwadratische factor (2026-07-29)
+- [ ] **`applyWbsNumbering` + `recomputeViewRows` draaien per mutatie.** `withTransaction`
+      (K-item 32) haalde de snapshot-kant eruit: bij 600 `addTask`-aanroepen ging het van
+      4528 ms naar 1533 ms en van 100 naar 1 undo-stap. Maar de schaling bleef ~3,5× bij een
+      verdubbeling van n, dus er is een tweede kwadratische factor: beide functies zijn O(n) en
+      worden n keer aangeroepen. `flattenOrder` is al gede-kwadrateerd, dus dát is het niet.
+      *Aanpak:* binnen een lopende batch de hernummering en de viewRows-herberekening uitstellen
+      tot het einde van de transactie. Let op: dan ziet code BÍNNEN de batch verouderde
+      `wbsCode`/`viewRows` — dat is een gedragswijziging, geen pure optimalisatie, en hoort
+      daarom niet stilzwijgend in K-item 32. Hangt samen met item 36 (prestaties).
+
 ### Distributie & Release
 
 #### Sleutelbeheer — vier velden die alleen de eigenaar kan invullen (2026-07-28)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -86,7 +86,7 @@ module.exports = {
 | Onderdeel | Functies |
 |---|---|
 | `api.importers` | `register(def)`, `unregister(id)` |
-| `api.data` | `getProject/getCalendar/getTasks/getSequences/getResources/getAssignments`, `addTask`, `updateTask`, `addSequence`, `loadProject(result)`, `recalculate()` |
+| `api.data` | `getProject/getCalendar/getTasks/getSequences/getResources/getAssignments`, `addTask`, `updateTask`, `addSequence`, `loadProject(result)`, `recalculate()`, `batch(fn)` |
 | `api.events` | `on/off/emit` (permissie `events`) |
 | `api.ui` | `addRibbonButton(reg)` (permissie `ribbon`), `showNotification(msg, type?)` |
 | `api.settings` | `get(key, default)`, `set(key, value)` — per extensie geprefixt in localStorage |
@@ -94,6 +94,22 @@ module.exports = {
 | `api.pdfFonts` | `register(provider)` (permissie `pdf-fonts`) — font-provider voor de vector-PDF-export; automatisch uitgeschreven bij disable |
 
 Belangrijk: na het muteren van taken/relaties zelf `api.data.recalculate()` aanroepen — het schema wordt niet reactief herberekend. `loadProject()` doet dat automatisch.
+
+**Muteer je meer dan een handvol dingen in een lus, wikkel dat dan in `api.data.batch()`.** Elke
+losse mutatie legt anders een eigen undo-snapshot aan: honderd taken toevoegen kost honderd
+snapshots (de kosten lopen kwadratisch op) en laat honderd undo-stappen achter voor wat de
+gebruiker als één handeling ziet. Binnen `batch` wordt de snapshot één keer genomen:
+
+```js
+api.data.batch(() => {
+  for (const row of rows) api.data.addTask({ name: row.naam });
+});
+api.data.recalculate();
+```
+
+`batch` kent geen rollback: gooit je callback halverwege, dan blijft staan wat al gemuteerd is —
+maar de ene snapshot dekt de begintoestand, dus de gebruiker draait het in één keer terug.
+Nesten mag; de binnenste `batch` doet dan niets extra's.
 
 ### Binaire assets & font-providers
 

--- a/src/extensions/extensionApi.ts
+++ b/src/extensions/extensionApi.ts
@@ -13,6 +13,7 @@ import type {
 } from './types';
 import type { ExtImportResult } from './extTypes';
 import { useAppStore } from '@/state/appStore';
+import { withTransaction } from '@/state/batchTransaction';
 import { appLog } from '@/services/debug/appLog';
 import { registerCjkFontProvider, type CjkFontProvider } from '@/services/pdf/fontRegistry';
 import {
@@ -82,6 +83,9 @@ export function createExtensionApi(
         store.runCPM();
       },
       recalculate: () => useAppStore.getState().runCPM(),
+      // K-item 32: één snapshot voor de hele reeks i.p.v. één per mutatie — lineair in plaats van
+      // kwadratisch, en één undo-stap voor wat de gebruiker als één handeling ziet.
+      batch: <T,>(fn: () => T): T => withTransaction(fn),
     },
 
     events: {

--- a/src/extensions/permissions.ts
+++ b/src/extensions/permissions.ts
@@ -68,6 +68,7 @@ export const API_PERMISSIONS: Record<string, PermissionCheck | null> = {
   'data.addSequence': null,
   'data.loadProject': null,
   'data.recalculate': null,
+  'data.batch': null,
 
   // Settings — kern-API.
   'settings.get': null,

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -137,6 +137,22 @@ export interface ExtensionApi {
     loadProject(result: ExtImportResult): void;
     /** runCPM — herbereken het schema. */
     recalculate(): void;
+    /**
+     * Voer een reeks mutaties uit als ÉÉN ongedaan-maakbare stap.
+     *
+     * Zonder dit pusht elke `addTask`/`updateTask` zijn eigen deep-clone-snapshot: een lus van n
+     * toevoegingen kloont 1 + 2 + … + n taken (kwadratisch) en laat n undo-stappen achter voor wat
+     * de gebruiker als één handeling ziet. Binnen `batch` wordt de snapshot één keer genomen.
+     *
+     * Gebruik dit voor élke lus die meer dan een handvol mutaties doet — een importer bijvoorbeeld:
+     *
+     *   api.data.batch(() => { for (const t of rows) api.data.addTask(t); });
+     *   api.data.recalculate();
+     *
+     * Geen rollback bij een fout: gooit de callback, dan blijft wat al gemuteerd is staan en dekt de
+     * ene snapshot de begintoestand — de gebruiker draait het in één keer terug. Nesten is veilig.
+     */
+    batch<T>(fn: () => T): T;
   };
 
   /** Globale event-bus (permissie 'events' vereist). */

--- a/src/state/batchTransaction.ts
+++ b/src/state/batchTransaction.ts
@@ -1,0 +1,47 @@
+import { useAppStore } from './appStore';
+import { pushUndoSnapshot, enterBatch, exitBatch, isBatchActive, resetUndoCoalescing } from './transaction';
+
+/**
+ * Voer een reeks mutaties uit als ÉÉN ongedaan-maakbare stap (K-item 32).
+ *
+ * Het probleem. Elke mutator pusht zijn eigen deep-clone-snapshot. Een lus van n toevoegingen
+ * kloont daardoor 1 + 2 + … + n taken — zuiver kwadratisch. Dat is geen theorie: `api.data.addTask`
+ * is de enige manier waarop een extensie taken kan aanmaken, dus een importer die duizend taken
+ * toevoegt betaalt duizend snapshots én laat duizend undo-stappen achter voor wat de gebruiker als
+ * één handeling ziet.
+ *
+ * Deze functie neemt de snapshot één keer vooraf en onderdrukt die van de mutators. Kosten worden
+ * lineair, en één bulk = één undo-stap.
+ *
+ * Bewust GEEN rollback bij een fout — dat is wat `runInMcpTransaction` doet, en dat vraagt om een
+ * herintreedbaarheids-guard plus het terugzetten van de redo-stack. Hier is de belofte smaller en
+ * eerlijker: één undo-stap en lineaire kosten. Gooit `fn`, dan blijft wat er al gemuteerd is staan
+ * en dekt de ene snapshot precies de begintoestand — de gebruiker kan het in één keer terugdraaien.
+ *
+ * Genest aanroepen is veilig: de binnenste doet niets extra's, want de buitenste snapshot dekt de
+ * hele reeks al. Vandaar een diepteteller in plaats van een vlag.
+ */
+export function withTransaction<T>(fn: () => T): T {
+  if (isBatchActive()) return fn(); // genest: de buitenste transactie dekt dit al
+
+  // Een bulk breekt een lopende coalescing-reeks af — anders zou de eerstvolgende toetsaanslag in
+  // een datumveld op déze snapshot willen doorbouwen.
+  resetUndoCoalescing();
+
+  // De snapshot van de PLAIN pre-transactie-staat, niet van een draft (zie beginUndoable/B1: op een
+  // draft proxy't de JSON-kloon élk bezocht object — gemeten ~145 ms bij 5.000 taken tegen ~19 ms).
+  const base = useAppStore.getState();
+  useAppStore.setState((s) => {
+    pushUndoSnapshot(s, base);
+    s.redoStack = [];
+  });
+
+  enterBatch();
+  try {
+    return fn();
+  } finally {
+    // `finally`, zodat een throw in `fn` de suppressie niet laat hangen: elke volgende mutatie in
+    // de app zou dan stilzwijgend geen undo-stap meer opleveren.
+    exitBatch();
+  }
+}

--- a/src/state/transaction.ts
+++ b/src/state/transaction.ts
@@ -96,6 +96,34 @@ export function setMcpTransactionActive(active: boolean): void {
 }
 
 /**
+ * Diepteteller voor bulk-transacties (K-item 32).
+ *
+ * Zonder dit pusht élke mutator zijn eigen deep-clone-snapshot. Een lus van n toevoegingen kloont
+ * dus 1 + 2 + … + n taken — kwadratisch. Dat gebeurt echt: `api.data.addTask` is de enige manier
+ * waarop een extensie taken kan aanmaken, dus een importer die duizend taken toevoegt betaalt
+ * duizend snapshots én laat duizend undo-stappen achter voor wat de gebruiker als één handeling ziet.
+ *
+ * Een TELLER en geen boolean, zodat een geneste `withTransaction` de buitenste niet voortijdig
+ * opheft. Module-state, net als de coalesce-marker en de MCP-vlag: een uitvoerings-"venster",
+ * geen documentdata.
+ */
+let batchDepth = 0;
+
+/** Loopt er een bulk-transactie? Dan neemt die de ene snapshot en zwijgen de mutators. */
+export function isBatchActive(): boolean {
+  return batchDepth > 0;
+}
+
+/** Uitsluitend door `withTransaction` aangeroepen, synchroon rond de callback (ook bij een throw). */
+export function enterBatch(): void {
+  batchDepth++;
+}
+
+export function exitBatch(): void {
+  if (batchDepth > 0) batchDepth--;
+}
+
+/**
  * Open een ongedaan-maakbare mutatie: leg de huidige staat op de undo-stack en wis de redo-stack.
  * ROEP DIT AAN NÁ eventuele guard-returns en VÓÓR de mutatie — zo vervuilt een no-op de undo-stack
  * niet (bewust patroon door de hele state-laag: acties pushen de snapshot pas als er echt iets
@@ -111,9 +139,10 @@ export function setMcpTransactionActive(active: boolean): void {
  * dezelfde bewerking vallen samen.
  */
 export function beginUndoable(s: AppState, opts?: { coalesceKey?: string }): void {
-  // WP0-suppressie: binnen een MCP-transactie neemt `runInMcpTransaction` zelf één snapshot vooraf;
-  // de individuele mutators mogen er dan géén pushen. Early-return vóór álle snapshot-/coalesce-logica.
-  if (mcpTransactionActive) return;
+  // Suppressie: binnen een MCP-transactie (WP0) óf een bulk-transactie (`withTransaction`,
+  // K-item 32) is de ene snapshot al vooraf genomen; de individuele mutators mogen er dan géén
+  // pushen. Early-return vóór álle snapshot-/coalesce-logica.
+  if (mcpTransactionActive || batchDepth > 0) return;
   const key = opts?.coalesceKey;
   if (key && coalesce && coalesce.key === key && coalesce.seq === undoSeq && coalesce.docId === s.activeDocumentId) {
     // Voortzetting van dezelfde bewerking: de bestaande snapshot dekt de begintoestand al.

--- a/tests/planning/check-undo-bound.ts
+++ b/tests/planning/check-undo-bound.ts
@@ -12,6 +12,7 @@
 // Draait via run.sh. Exit 0 = alles groen.
 import { useAppStore } from '@/state/appStore';
 import { MAX_UNDO } from '@/state/transaction';
+import { withTransaction } from '@/state/batchTransaction';
 
 const S = () => useAppStore.getState();
 const diffs: string[] = [];
@@ -94,6 +95,51 @@ S().redo();
 eq('16 redo herstelt de bewerking', S().tasks.find(t => t.id === id4)?.name, `r-${MAX_UNDO + OVER}`);
 eq('17 redo laat de stack niet over de grens groeien', S().undoStack.length <= MAX_UNDO, true);
 truthy('18 undo na redo werkt nog', (S().undo(), S().tasks.find(t => t.id === id4)?.name === naEersteUndo));
+
+// ── withTransaction: één bulk = één undo-stap (K-item 32) ─────────────────────
+// Elke mutator pusht normaal zijn eigen deep-clone-snapshot. Een lus van n toevoegingen kloont dus
+// 1 + 2 + … + n taken én laat n undo-stappen achter voor wat de gebruiker als één handeling ziet.
+// `api.data.batch` (extensies) draait hierop.
+{
+  S().newProject();
+  const N = 25;
+
+  const before = S().undoStack.length;
+  for (let i = 0; i < N; i++) S().addTask({ name: `zonder-${i}` });
+  eq('bt1 zonder batch: n mutaties ⇒ n undo-stappen', S().undoStack.length - before, N);
+
+  S().newProject();
+  const beforeBatch = S().undoStack.length;
+  withTransaction(() => { for (let i = 0; i < N; i++) S().addTask({ name: `met-${i}` }); });
+  eq('bt2 met batch: n mutaties ⇒ precies één undo-stap', S().undoStack.length - beforeBatch, 1);
+  eq('bt3 met batch: alle taken zijn er wél', S().tasks.filter(t => t.name.startsWith('met-')).length, N);
+
+  // Die ene stap moet de HELE reeks terugdraaien — anders is "één undo-stap" een lege belofte.
+  S().undo();
+  eq('bt4 undo draait de hele bulk in één keer terug', S().tasks.filter(t => t.name.startsWith('met-')).length, 0);
+
+  // Nesten is veilig: de binnenste transactie mag de buitenste niet voortijdig opheffen.
+  S().newProject();
+  const beforeNest = S().undoStack.length;
+  withTransaction(() => {
+    S().addTask({ name: 'buiten' });
+    withTransaction(() => { S().addTask({ name: 'binnen-1' }); S().addTask({ name: 'binnen-2' }); });
+    S().addTask({ name: 'buiten-2' });
+  });
+  eq('bt5 geneste batch levert nog steeds één undo-stap', S().undoStack.length - beforeNest, 1);
+  eq('bt6 geneste batch: alle vier de taken staan er', S().tasks.length, 4);
+
+  // Gooit de callback, dan mag de suppressie NIET blijven hangen — anders levert elke volgende
+  // mutatie in de app stilzwijgend geen undo-stap meer op.
+  S().newProject();
+  try {
+    withTransaction(() => { S().addTask({ name: 'voor-de-fout' }); throw new Error('boem'); });
+  } catch { /* verwacht */ }
+  const afterThrow = S().undoStack.length;
+  S().addTask({ name: 'na-de-fout' });
+  eq('bt7 na een throw in de batch pusht een gewone mutatie weer een undo-stap',
+    S().undoStack.length - afterThrow, 1);
+}
 
 // ── Uitslag ──────────────────────────────────────────────────────────────────
 if (diffs.length === 0) {


### PR DESCRIPTION
Item 32 uit fase "structureel" (`docs/onderhoudbaarheid/README.md` §5).

## Het probleem

Elke mutator pusht zijn eigen deep-clone-snapshot, dus een lus van *n* toevoegingen kloont 1 + 2 + … + *n* taken. Geen theoretisch geval: `api.data.addTask` is de **enige** manier waarop een extensie taken kan aanmaken, dus een importer die duizend rijen inleest betaalt duizend snapshots — én laat duizend undo-stappen achter voor wat de gebruiker als één handeling ziet.

## De fix

`withTransaction(fn)` neemt de snapshot één keer vooraf en onderdrukt die van de mutators, via een **diepteteller** naast de bestaande MCP-suppressievlag. Een teller en geen boolean, zodat een geneste transactie de buitenste niet voortijdig opheft. Blootgesteld aan extensies als `api.data.batch(fn)`.

Bewust **geen rollback** — dat is wat `runInMcpTransaction` doet, en dat vraagt om een herintreedbaarheids-guard plus het herstellen van de redo-stack. De belofte hier is smaller en eerlijker: één undo-stap en lagere kosten.

## Gemeten

| n = 600 × `addTask` | tijd | undo-stappen |
|---|---|---|
| zonder batch | 4528 ms | 100 (het `MAX_UNDO`-plafond) |
| met batch | **1533 ms** | **1** |

## Wat deze wijziging *niet* oplost

De **schaling** blijft ~3,5× bij een verdubbeling van n. Er is dus een tweede kwadratische factor die hier niet door geraakt wordt: `applyWbsNumbering` en `recomputeViewRows` zijn allebei O(n) en worden *n* keer aangeroepen. (`flattenOrder` is al eerder gede-kwadrateerd, dus dát is het niet.)

Die uitstellen tot het einde van een batch kán, maar dan ziet code **binnen** de batch verouderde `wbsCode`/`viewRows` — een gedragswijziging, geen pure optimalisatie. Dat plak ik niet stilzwijgend aan dit item; genoteerd in `docs/TODO.md`, hangt samen met item 36.

## Verificatie

Zeven checks in `check-undo-bound.ts` (18 → 25), met twee negatieve controles:

| sabotage | resultaat |
|---|---|
| `exitBatch` uit de `finally` halen | bt7 valt om — na een throw levert élke volgende mutatie stil geen undo-stap meer op |
| suppressie helemaal uitzetten | drie checks vallen om (26 i.p.v. 1 stap, undo draait de bulk niet terug, nesting) |

`npm run verify` groen: alle acht poorten. `docs/extensions.md` uitgebreid met wanneer en hoe je `batch` gebruikt, inclusief de rollback-beperking.

---
_Generated by [Claude Code](https://claude.ai/code/session_015yaZ7E5SSxM4kHpBwApi9R)_