### PR TITLE
feat(taakgrid): samenvattingen en mijlpalen herkenbaar in de naamkolom (discussion #97)

### DIFF
--- a/public/docs/en/gids-plannen-wbs.md
+++ b/public/docs/en/gids-plannen-wbs.md
@@ -25,6 +25,8 @@ A flat list of tasks says nothing about how they relate. By indenting a task und
 
 As soon as a task has at least one subtask, it automatically becomes a summary task: its bar in the Gantt chart then spans the full period from the earliest start to the latest finish of all subtasks beneath it, and its own duration and dates can no longer be set independently. A summary task is therefore normally always a derived value, never a schedule you enter directly — delete or shift the subtasks, and the summary task's bar adjusts itself automatically. One exception: a **manually scheduled** summary task (that flag arises from a `.mpp` import) does *not* roll up — it keeps its own stored dates, even when its subtasks shift.
 
+**Recognizable in the name column.** In the task table (the **Table** tab, and the same name column in the right rail) a summary task shows in bold with a subtle background tint on the name cell; a milestone shows in bold in the same colour as its bar in the Gantt chart. A regular task stays unchanged. This is purely visual — it doesn't change how you select, drag, or edit a task.
+
 **Collapse and expand.** With a large WBS you'll sometimes want to compact the tree temporarily. The **View** ribbon tab, **Outline** group, has two separate buttons for this — **Collapse** and **Expand** — deliberately not a single toggle, because with a mixed selection (some branches open, others closed) a toggle could never set everything the same way.
 
 - **With a selection**, the buttons act on the selected tasks; only tasks with subtasks are affected, standalone tasks are ignored.

--- a/public/docs/nl/gids-plannen-wbs.md
+++ b/public/docs/nl/gids-plannen-wbs.md
@@ -25,6 +25,8 @@ Een platte lijst taken vertelt niets over samenhang. Door taken in te laten spri
 
 Zodra een taak minstens één subtaak heeft, wordt hij automatisch een samenvattende taak: de balk in het Gantt-diagram overspant dan de volledige periode van de vroegste start tot de laatste finish van alle subtaken eronder, en zijn eigen duur en data zijn niet langer los in te stellen. Een samenvattende taak is dus normaal gesproken altijd een afgeleide, geen los ingevoerde planning — verwijder of verschuif je de subtaken, dan past de balk van de samenvattende taak zich vanzelf aan. Eén uitzondering: een **handmatig geplande** samenvattingstaak (die vlag ontstaat bij een `.mpp`-import) rolt juist niét op — die houdt haar eigen opgeslagen datums, ook als haar subtaken verschuiven.
 
+**Herkenbaar in de naamkolom.** In de taaktabel (het tabblad **Tabel**, en dezelfde naamkolom in de rechterrail) staat een samenvattende taak vet en met een subtiele achtergrondtint op de naamcel; een mijlpaal staat vet in dezelfde kleur als zijn balk in het Gantt-diagram. Een gewone taak blijft ongewijzigd. Dat is puur visueel — er verandert niets aan hoe je een taak selecteert, sleept of bewerkt.
+
 **Inklappen en uitklappen.** Bij een grote WBS wil je de boom soms tijdelijk compacter maken. Het lint-tabblad **Beeld**, groep **Overzicht**, heeft daarvoor twee aparte knoppen — **Inklappen** en **Uitklappen** — bewust geen schakelaar, want bij een gemengde selectie (de ene tak open, de andere dicht) kan een schakelaar nooit alles dezelfde kant op zetten.
 
 - **Met een selectie** werken de knoppen op de geselecteerde taken; alleen taken mét subtaken doen mee, losse taken worden genegeerd.

--- a/src/components/task-grid/FullTaskGrid.tsx
+++ b/src/components/task-grid/FullTaskGrid.tsx
@@ -689,10 +689,15 @@ export function TaskGridSurface({
     // resterende kolombreedte volledig benut.
     const renderNameRow = (summary: Task, body: ReactNode, editingName: boolean): ReactNode => {
       const hasDisclosure = summary.childIds.length > 0;
+      // Discussion #97: samenvattingen en mijlpalen krijgen een licht typografisch accent in de
+      // naamkolom, gestuurd via dit attribuut — CSS doet de rest (vet, tint, mijlpaalkleur).
+      // Tijdens het bewerken van de naam blijft het editorveld ongemoeid (geen attribuut daarop).
+      const taskKind = summary.isMilestone ? 'milestone' : hasDisclosure ? 'summary' : undefined;
       return (
         <span
           className="full-task-grid-name"
           data-grid-name-depth={row.depth}
+          {...(taskKind && !editingName ? { 'data-grid-task-kind': taskKind } : {})}
           style={{ paddingInlineStart: taskNameIndent(row.depth, hasDisclosure, nameIndentMode) }}
         >
           {hasDisclosure && (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -414,6 +414,33 @@
   gap: 4px;
 }
 
+/* Discussion #97: samenvattingen (containertaken) en mijlpalen zijn nu alleen via inspringing te
+ * onderscheiden van een gewone taak. `data-grid-task-kind` (gezet in FullTaskGrid.tsx, weggelaten
+ * tijdens naam-editing) stuurt hier vet + een subtiele achtergrondtint voor samenvattingen, en
+ * vet + de mijlpaalkleur voor mijlpalen — bewust dezelfde kleurfamilie als de Gantt-balk
+ * (`--color-task-milestone`), niet de rode mockupkleur uit de discussion. De tint zit op de hele
+ * naamrij (niet alleen de tekst), zodat hij als rijvlak leesbaar is; de selectiekleur van de rij
+ * (`.task-grid-data-row[data-grid-row-selected="true"]`) wint hier altijd van, dus geen eigen
+ * z-index-gedoe nodig — de tint zit hieronder in de laagvolgorde. */
+.full-task-grid-name[data-grid-task-kind="summary"] {
+  background: var(--theme-grid-summary-bg);
+}
+
+.full-task-grid-name[data-grid-task-kind="summary"] .full-task-grid-name-label {
+  font-weight: 600;
+}
+
+.full-task-grid-name[data-grid-task-kind="milestone"] .full-task-grid-name-label {
+  font-weight: 600;
+  color: var(--theme-grid-milestone-text);
+}
+
+/* Geselecteerde rij wint van de samenvattingstint (leesbaarheid op de selectiekleur staat voorop);
+ * de vette/gekleurde tekst blijft intact — alleen de achtergrond van de naamrij vervalt. */
+.task-grid-data-row[data-grid-row-selected="true"] .full-task-grid-name[data-grid-task-kind="summary"] {
+  background: transparent;
+}
+
 /* De naameditor vult de rij vanaf de tekstpositie tot de rechter kolomrand. */
 .full-task-grid-name > .task-grid-editor-host {
   flex: 1 1 auto;
@@ -1240,6 +1267,12 @@ button.task-grid-relation-reference {
   /* Om-en-om weekband bij gecomprimeerde as (issue #21 punt 2): dekt hele weken (5+ kolommen
      aaneen), dus bewust nog subtieler dan de per-dag weekend-arcering hierboven. */
   --theme-grid-week-band: rgba(255, 255, 255, 0.028);
+  /* Discussion #97: subtiele achtergrondtint voor samenvattingsrijen in het taakraster (naamkolom)
+     — dezelfde alpha-aanpak als de weekendarcering hierboven, zodat het geen eigen kleurfamilie
+     introduceert. Mijlpalen krijgen géén tint, alleen vette tekst in een lichtere paarstint
+     (beter leesbaar op donkere kaarten dan --color-task-milestone zelf). */
+  --theme-grid-summary-bg: rgba(255, 255, 255, 0.045);
+  --theme-grid-milestone-text: #A78BFA;
   --theme-bar-float: #10B981;
   --theme-critical-text: #F87171;
   --theme-input-bg: #23262D;
@@ -1314,6 +1347,11 @@ button.task-grid-relation-reference {
   /* Om-en-om weekband bij gecomprimeerde as (issue #21 punt 2): subtieler dan de weekend-
      arcering, want hij bedekt hele weken i.p.v. losse dagkolommen. */
   --theme-grid-week-band: rgba(54, 54, 62, 0.03);
+  /* Discussion #97: zelfde neutrale-grijsschaal-aanpak als de rest van dit lichte thema — een
+     alpha-tint van Deep Forge, geen eigen kleur. Mijlpaaltekst gaat iets dieper dan
+     --color-task-milestone (#7C3AED) voor voldoende contrast op de kaart (AA). */
+  --theme-grid-summary-bg: rgba(54, 54, 62, 0.06);
+  --theme-grid-milestone-text: #6D28D9;
   --theme-bar-float: #059669;
   --theme-critical-text: #C81E1E; /* 5.5:1 op de kaart, 4.6:1 op de werkruimte */
   --theme-input-bg: #FFFFFF;
@@ -1366,6 +1404,12 @@ button.task-grid-relation-reference {
      weekend-band maar nog zichtbaar op #0a0a0a (de band moet als vlak leesbaar blijven,
      niet als per-dag-arcering concurreren). */
   --theme-grid-week-band: #141414;
+  /* Discussion #97: het paars van --color-task-milestone haalt op zwart geen AAA-contrast, dus
+     high contrast krijgt een eigen, helderdere mijlpaaltint (>=7:1 op #0a0a0a) — zichtbaar
+     onderscheiden van het accentgeel. De samenvattingstint volgt de bestaande vlakke-kleur-aanpak
+     van dit thema (geen alpha, expliciete tint zoals --theme-grid-weekend hierboven). */
+  --theme-grid-summary-bg: #1c1c1c;
+  --theme-grid-milestone-text: #D9A6FF;
   /* Gantt float-balk: heldere emerald op zwart (op ~90% opacity 8.85:1). */
   --theme-bar-float: #34D399;
   /* Kritieke-pad-tekst: helder rood, >=4.5:1 op #0a0a0a/#000 (7.1–7.6:1). */

--- a/tests/browser/task-grid-name-emphasis.spec.ts
+++ b/tests/browser/task-grid-name-emphasis.spec.ts
@@ -1,0 +1,80 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect, seedProject, test } from './fixtures/ops';
+
+// Discussion #97: de naamkolom van het taakraster gaf samenvattingen (containertaken) en
+// mijlpalen geen enkel typografisch signaal — alleen de inspringing verried de hiërarchie. Dit
+// karakteriseert het `data-grid-task-kind`-attribuut dat FullTaskGrid nu op de naamrij zet en de
+// bijbehorende CSS in globals.css (vet voor samenvatting/mijlpaal, plus de mijlpaalkleur):
+// echte DOM-attributen en computed styles, geen canvaspixels.
+
+function nameSpan(page: Page, taskId: string): Locator {
+  return page.locator(
+    `[data-task-grid-surface-id="full-task-grid"] [data-grid-data-row="true"][data-grid-row-key="${taskId}"] .full-task-grid-name`,
+  );
+}
+
+test('samenvatting en mijlpaal krijgen een eigen data-grid-task-kind en typografie in de naamkolom', async ({ page, ops: _ops }) => {
+  const [summaryId, milestoneId, normalId] = await seedProject(page, [
+    { name: 'Fase 1', start: '2026-09-07', finish: '2026-09-25' },
+    { name: 'Oplevering', start: '2026-09-07', finish: '2026-09-07' },
+    { name: 'Gewone taak', start: '2026-09-07', finish: '2026-09-18' },
+  ]);
+
+  // seedProject maakt platte taken aan; maak er hier een echte samenvatting (kind erbij) en een
+  // echte mijlpaal van via de publieke store-acties, en herbereken.
+  await page.evaluate((parentId) => {
+    const s = window.__OPS__!.store.getState();
+    const id = s.addTask({ name: 'Onderdeel', parentId, manuallyScheduled: true });
+    const created = window.__OPS__!.store.getState().tasks.find(t => t.id === id)!;
+    s.updateTask(id, {
+      time: {
+        ...created.time,
+        scheduleStart: '2026-09-07',
+        scheduleFinish: '2026-09-11',
+        earlyStart: '2026-09-07',
+        earlyFinish: '2026-09-11',
+        scheduleDuration: 5,
+      },
+    });
+  }, summaryId);
+  await page.evaluate((id) => {
+    const s = window.__OPS__!.store.getState();
+    s.updateTask(id, { isMilestone: true });
+  }, milestoneId);
+  await page.evaluate(() => window.__OPS__!.store.getState().runCPM());
+  await expect.poll(() => page.evaluate(() => window.__OPS__!.store.getState().tasks.length)).toBe(4);
+
+  await page.getByRole('button', { name: /^(Table|Tabel)$/ }).click();
+  const grid = page.locator('[data-task-grid-surface-id="full-task-grid"] [role="grid"]');
+  await expect(grid).toBeVisible();
+
+  const summarySpan = nameSpan(page, summaryId);
+  const milestoneSpan = nameSpan(page, milestoneId);
+  const normalSpan = nameSpan(page, normalId);
+  await expect(summarySpan).toBeVisible();
+  await expect(milestoneSpan).toBeVisible();
+  await expect(normalSpan).toBeVisible();
+
+  await expect(summarySpan).toHaveAttribute('data-grid-task-kind', 'summary');
+  await expect(milestoneSpan).toHaveAttribute('data-grid-task-kind', 'milestone');
+  await expect.poll(() => normalSpan.getAttribute('data-grid-task-kind')).toBeNull();
+
+  const summaryLabel = summarySpan.locator('.full-task-grid-name-label');
+  const milestoneLabel = milestoneSpan.locator('.full-task-grid-name-label');
+  const normalLabel = normalSpan.locator('.full-task-grid-name-label');
+
+  const [summaryWeight, milestoneWeight, normalWeight] = await Promise.all([
+    summaryLabel.evaluate(node => Number(getComputedStyle(node).fontWeight)),
+    milestoneLabel.evaluate(node => Number(getComputedStyle(node).fontWeight)),
+    normalLabel.evaluate(node => Number(getComputedStyle(node).fontWeight)),
+  ]);
+  expect(summaryWeight).toBeGreaterThanOrEqual(600);
+  expect(milestoneWeight).toBeGreaterThanOrEqual(600);
+  expect(normalWeight).toBeLessThan(600);
+
+  const [milestoneColor, normalColor] = await Promise.all([
+    milestoneLabel.evaluate(node => getComputedStyle(node).color),
+    normalLabel.evaluate(node => getComputedStyle(node).color),
+  ]);
+  expect(milestoneColor).not.toBe(normalColor);
+});


### PR DESCRIPTION
Uitwerking van discussion #97 van @manuvarkey: de **Taaknaam**-kolom laat containers en mijlpalen nu ook typografisch zien, niet alleen via inspringing.

- **Samenvattende taak:** vet + subtiele achtergrondtint op de naamcel (verdwijnt op een geselecteerde rij, zodat de selectiekleur leesbaar blijft).
- **Mijlpaal:** vet in de mijlpaalkleur, dezelfde kleurfamilie als de Gantt-balk (bewust niet het rood uit de mockup).
- **Gewone taak:** ongewijzigd. Inspringing en klapdriehoekje blijven zoals ze waren.
- Eigen tokens per thema (dark, light, high-contrast) voor contrast.
- Browsertest `tests/browser/task-grid-name-emphasis.spec.ts`; gids *Plannen met een WBS* (nl+en) bijgewerkt.

Lokaal groen: typecheck, lint, verify:docs, de nieuwe browsertest. Visueel gecontroleerd in light en dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)