### PR TITLE
Verwijder contour-engine, waarschuwingenpaneel en gerelateerde code

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -144,6 +144,14 @@ jobs:
         uses: snapcore/action-build@v1
         id: snapcraft
 
+      # Tauri sluit frontendDist in de executable in; een gewone lijst van de Snap-inhoud ziet de
+      # docs daarom niet als losse files. Controleer de échte Snap-binary tegen de public/docs-bron
+      # van exact deze checkout voordat hij als release-asset of Store-publicatie verdergaat.
+      - name: Verify embedded Help documentation in Snap
+        env:
+          SNAP: ${{ steps.snapcraft.outputs.snap }}
+        run: node scripts/verify-package-docs.mjs --snap "$SNAP"
+
       # Echte release (via workflow_run): snap als asset aan de release hangen.
       - name: Upload snap to GitHub release
         if: github.event_name == 'workflow_run'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,6 +50,7 @@ aangeroepen:
 | `bump-version.js` | `npm run bump X.Y.Z` | CalVer synchroon zetten in `package.json`, `tauri.conf.json` en de lockfile (`Cargo.toml` blijft bewust `0.1.0`) |
 | `release-notes.mjs` | `.github/workflows/release.yml` (twee plekken) | `docs/release-notes/v<versie>.md` → `--format=body` voor de GitHub-releasepagina, `--format=notes` (platte tekst) voor het `notes`-veld in `latest.json` |
 | `release-highlights.mjs` | `npm run verify:release-highlights` | start de getypeerde releasehighlight-verifier: eist één volledig versieblok met 14 locales, één primary en vier secondary-kaarten zonder gidslink, veilige pictogrammen en reproduceerbare Git-cijfers; docs, vertalingen, lock-, gegenereerde en vendorbestanden tellen niet mee |
+| `verify-package-docs.mjs` | `.github/workflows/snap.yml`, direct na de Snap-build | leest de executable uit de zojuist gebouwde Snap en eist dat het manifest plus de aanwezige Help-artikelen uit `public/docs/` als Tauri-assets zijn ingesloten, vóór upload of Store-publicatie |
 | `publish-wiki.mjs` | `npm run publish:wiki` | genereert de GitHub-wiki uit `public/docs/en`, `docs/wiki/*` en de changelog. De wiki is een build-artefact — nooit met de hand bewerken |
 
 ## Overig

--- a/scripts/verify-package-docs.mjs
+++ b/scripts/verify-package-docs.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Verifieert de door Tauri in de Linux-binary ingesloten Help-assets. Tauri bundelt `frontendDist`
+// in de executable; daarom zijn docs niet als losse bestanden zichtbaar in de deb/Snap-bestandslijst.
+// Deze poort leest de echte executable bytes en zoekt elke bronasset als Tauri asset-pad op.
+//
+//   node scripts/verify-package-docs.mjs --binary /pad/naar/open-planner-studio
+//   node scripts/verify-package-docs.mjs --snap /pad/naar/open-planner-studio.snap
+//
+// `--docs-root` is alleen voor forensische controle van een historisch package tegen zijn exacte
+// bronboom; de CI gebruikt altijd de huidige `public/docs` uit dezelfde checkout.
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+function usage(message) {
+  if (message) console.error(`Fout: ${message}`);
+  console.error('Gebruik: node scripts/verify-package-docs.mjs (--binary <pad> | --snap <pad>) [--docs-root <public/docs>]');
+  process.exit(2);
+}
+
+const args = process.argv.slice(2);
+const valueOf = (flag) => {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+};
+const binaryArg = valueOf('--binary');
+const snapArg = valueOf('--snap');
+const docsRoot = resolve(valueOf('--docs-root') ?? 'public/docs');
+if ((binaryArg ? 1 : 0) + (snapArg ? 1 : 0) !== 1) usage('geef precies één van --binary of --snap op');
+if (!existsSync(docsRoot)) usage(`docs-map bestaat niet: ${docsRoot}`);
+
+function packageBinary() {
+  if (binaryArg) {
+    const path = resolve(binaryArg);
+    if (!existsSync(path)) usage(`binary bestaat niet: ${path}`);
+    return readFileSync(path);
+  }
+
+  const snap = resolve(snapArg);
+  if (!existsSync(snap)) usage(`Snap bestaat niet: ${snap}`);
+  const extracted = spawnSync('unsquashfs', ['-cat', snap, 'usr/bin/open-planner-studio'], {
+    encoding: null,
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  if (extracted.error) usage(`unsquashfs kon niet starten: ${extracted.error.message}`);
+  if (extracted.status !== 0) usage(`unsquashfs kon de executable niet lezen (exit ${extracted.status}): ${String(extracted.stderr)}`);
+  return extracted.stdout;
+}
+
+const manifestPath = resolve(docsRoot, 'manifest.json');
+if (!existsSync(manifestPath)) usage(`manifest ontbreekt: ${manifestPath}`);
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+if (!Array.isArray(manifest.articles)) usage(`manifest bevat geen articles-array: ${manifestPath}`);
+
+const localeDirs = Object.keys(manifest.articles[0]?.title ?? {}).sort();
+if (localeDirs.length === 0) usage('manifest bevat geen taalset in article-titels');
+const expected = ['/docs/manifest.json'];
+const perLocale = new Map();
+for (const locale of localeDirs) {
+  const folder = resolve(docsRoot, locale);
+  if (!existsSync(folder)) usage(`docs-map voor ${locale} ontbreekt: ${folder}`);
+  const paths = manifest.articles
+    .map(article => `${locale}/${article.id}.md`)
+    .filter(relative => existsSync(resolve(docsRoot, relative)));
+  if (paths.length === 0) usage(`docs-map voor ${locale} bevat geen manifest-artikelen`);
+  perLocale.set(locale, paths);
+  expected.push(...paths.map(relative => `/docs/${relative}`));
+}
+
+const binary = packageBinary();
+const missing = expected.filter(asset => !binary.includes(Buffer.from(asset)));
+console.log(`Controleer ${expected.length} Help-assets in ${snapArg ? `Snap ${resolve(snapArg)}` : `binary ${resolve(binaryArg)}`}`);
+for (const [locale, paths] of perLocale) {
+  const embedded = paths.filter(relative => binary.includes(Buffer.from(`/docs/${relative}`))).length;
+  console.log(`  ${embedded === paths.length ? 'OK' : 'XX'} ${locale}: ${embedded}/${paths.length} artikelen ingesloten`);
+}
+console.log(`  ${binary.includes(Buffer.from('/docs/manifest.json')) ? 'OK' : 'XX'} manifest.json`);
+
+if (missing.length > 0) {
+  console.error(`\nXX ${missing.length} Help-assets ontbreken in het package:`);
+  for (const asset of missing) console.error(`   - ${asset}`);
+  process.exit(1);
+}
+console.log(`\nAlles groen: ${expected.length} Help-assets zijn in het package ingesloten.`);

--- a/src/components/backstage/HelpPanel.tsx
+++ b/src/components/backstage/HelpPanel.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Search } from 'lucide-react';
 import { useAppStore } from '@/state/appStore';
-import { LANGUAGE_LABELS } from '@/i18n/config';
+import { LANGUAGE_LABELS, supportedLanguages, type Locale } from '@/i18n/config';
 import { renderMiniMarkdown, extractHeadings } from '@/utils/miniMarkdown';
 import { fetchTextAsset } from '@/utils/textAsset';
 import { applyDemoLibraryToShowcaseProject } from '@/state/demoLibraryShowcase';
@@ -22,8 +22,10 @@ type HelpLayer = 'quickstart' | 'gidsen' | 'referentie';
 
 // Alle UI-locales met een eigen vertaalde docs-map onder public/docs/<lang>/. Elke UI-taal die
 // hier niet in staat (of waarvan een specifiek artikel ontbreekt) valt terug op de EN-docs.
-const DOC_LANGS = ['nl', 'en', 'fr', 'de', 'es', 'zh', 'it', 'pt', 'pl', 'tr', 'ar', 'ja', 'ko', 'fa'] as const;
-type HelpLang = (typeof DOC_LANGS)[number];
+// De keuzelijst is exact de productbrede i18n-set. Daardoor kan een nieuwe UI-taal niet stil
+// ontbreken in Help; `verify:docs` bewaakt vervolgens dat elke taal ook een docs-map heeft.
+const DOC_LANGS = supportedLanguages;
+type HelpLang = Locale;
 
 function resolveDocLang(uiLang: string): HelpLang {
   const base = uiLang.split('-')[0];

--- a/src/components/dialogs/AiConnectionDetailsDialog.tsx
+++ b/src/components/dialogs/AiConnectionDetailsDialog.tsx
@@ -68,8 +68,13 @@ export function AiConnectionDetailsDialog({ port, token, onClose }: AiConnection
   const promptReal = promptFor(token);
   const promptShown = showToken ? promptReal : promptFor(MASK);
 
-  const copy = (text: string, key: string) => {
-    void navigator.clipboard?.writeText(text);
+  const copy = async (text: string, key: string) => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return;
+    }
     setCopied(key);
     setTimeout(() => setCopied(c => (c === key ? null : c)), 1500);
   };
@@ -77,7 +82,7 @@ export function AiConnectionDetailsDialog({ port, token, onClose }: AiConnection
   const copyButton = (text: string, key: string) => (
     <button
       type="button"
-      onClick={() => copy(text, key)}
+      onClick={() => { void copy(text, key); }}
       title={t('ai.copy')}
       aria-label={t('ai.copy')}
       className="shrink-0 p-1 border border-border rounded-[8px] hover:bg-surface-hover"

--- a/src/components/ribbon/ai/AiConnectionGroup.tsx
+++ b/src/components/ribbon/ai/AiConnectionGroup.tsx
@@ -72,8 +72,13 @@ export function AiConnectionGroup() {
   // Poort mag alleen wijzigen zolang de bridge niet draait (de draaiende server bindt de poort).
   const portLocked = serverState !== 'off';
 
-  const copy = (text: string, key: string) => {
-    void navigator.clipboard?.writeText(text);
+  const copy = async (text: string, key: string) => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return;
+    }
     setCopied(key);
     setTimeout(() => setCopied(c => (c === key ? null : c)), 1500);
   };
@@ -133,7 +138,7 @@ export function AiConnectionGroup() {
         style={iconBtnStyle}
         title={t('ai.copy')}
         aria-label={t('ai.copy')}
-        onClick={() => copy(token, 'token')}
+        onClick={() => { void copy(token, 'token'); }}
       >
         {copied === 'token' ? <Check size={13} /> : <Copy size={13} />}
       </button>

--- a/tests/browser/ai-connection-copy.spec.ts
+++ b/tests/browser/ai-connection-copy.spec.ts
@@ -6,7 +6,10 @@ const SYNTHETIC_PORT = 4319;
 const ENDPOINT = `http://localhost:${SYNTHETIC_PORT}/mcp`;
 const MASK = '••••••••••••••••';
 
-type CopyLogWindow = Window & { __opsA1Copied?: string[] };
+type CopyLogWindow = Window & {
+  __opsA1Copied?: string[];
+  __opsA1RejectNextCopy?: boolean;
+};
 
 function copyInSection(dialog: Locator, heading: RegExp) {
   return dialog.getByText(heading, { exact: true }).locator('..').getByRole('button', { name: /^(Copy|Kopiëren)$/ });
@@ -18,10 +21,16 @@ test('AI-verbindingsgegevens maskeren de UI maar kopiëren elke bruikbare echte 
     localStorage.setItem('ops-mcpPort', JSON.stringify(port));
 
     const copied: string[] = [];
+    Object.defineProperty(window, '__opsA1RejectNextCopy', { configurable: true, writable: true, value: false });
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: {
         writeText: (value: string) => {
+          const testWindow = window as CopyLogWindow;
+          if (testWindow.__opsA1RejectNextCopy) {
+            testWindow.__opsA1RejectNextCopy = false;
+            return Promise.reject(new Error('synthetische klembordfout'));
+          }
           copied.push(value);
           return Promise.resolve();
         },
@@ -44,6 +53,9 @@ test('AI-verbindingsgegevens maskeren de UI maar kopiëren elke bruikbare echte 
 
   const tokenControl = page.locator('input[type="password"]').locator('..');
   await expect(tokenControl).toBeVisible();
+  await page.evaluate(() => { (window as CopyLogWindow).__opsA1RejectNextCopy = true; });
+  await tokenControl.getByRole('button', { name: /^(Copy|Kopiëren)$/ }).click();
+  await expect(tokenControl.locator('svg.lucide-check')).toHaveCount(0);
   await tokenControl.getByRole('button', { name: /^(Copy|Kopiëren)$/ }).click();
 
   await page.getByRole('button', { name: /^(Connect|Verbinden)$/ }).click();

--- a/tests/browser/ai-connection-copy.spec.ts
+++ b/tests/browser/ai-connection-copy.spec.ts
@@ -1,0 +1,79 @@
+import { expect, type Locator } from '@playwright/test';
+import { test, waitForOps } from './fixtures/ops';
+
+const SYNTHETIC_TOKEN = 'a1-synthetic-token-not-a-secret';
+const SYNTHETIC_PORT = 4319;
+const ENDPOINT = `http://localhost:${SYNTHETIC_PORT}/mcp`;
+const MASK = '••••••••••••••••';
+
+type CopyLogWindow = Window & { __opsA1Copied?: string[] };
+
+function copyInSection(dialog: Locator, heading: RegExp) {
+  return dialog.getByText(heading, { exact: true }).locator('..').getByRole('button', { name: /^(Copy|Kopiëren)$/ });
+}
+
+test('AI-verbindingsgegevens maskeren de UI maar kopiëren elke bruikbare echte waarde', async ({ page, ops: _ops }) => {
+  await page.addInitScript(({ token, port }) => {
+    localStorage.setItem('ops-mcpToken', token);
+    localStorage.setItem('ops-mcpPort', JSON.stringify(port));
+
+    const copied: string[] = [];
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (value: string) => {
+          copied.push(value);
+          return Promise.resolve();
+        },
+      },
+    });
+    Object.defineProperty(window, '__opsA1Copied', { configurable: true, value: copied });
+  }, { token: SYNTHETIC_TOKEN, port: SYNTHETIC_PORT });
+  await page.reload();
+  await waitForOps(page);
+
+  await page.evaluate(() => {
+    window.__OPS__!.store.getState().setUI({
+      aiMode: true,
+      activeRibbonTab: 'ai',
+      ribbonCompact: false,
+      showWelcomeDialog: false,
+      showTourOverlay: false,
+    });
+  });
+
+  const tokenControl = page.locator('input[type="password"]').locator('..');
+  await expect(tokenControl).toBeVisible();
+  await tokenControl.getByRole('button', { name: /^(Copy|Kopiëren)$/ }).click();
+
+  await page.getByRole('button', { name: /^(Connect|Verbinden)$/ }).click();
+  const dialog = page.locator('[data-ops-ai-connection-dialog]');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).not.toContainText(SYNTHETIC_TOKEN);
+  await expect(dialog).toContainText(MASK);
+
+  await copyInSection(dialog, /^(Endpoint)$/).click();
+  await copyInSection(dialog, /^(Authentication|Authenticatie)$/).click();
+  await copyInSection(dialog, /^(Configuration snippet|Configuratiefragment)$/).click();
+  await copyInSection(dialog, /^(Connection prompt|Koppelprompt)$/).click();
+
+  const copied = await page.evaluate(() => (window as CopyLogWindow).__opsA1Copied);
+  expect(copied).toHaveLength(5);
+  expect(copied![0]).toBe(SYNTHETIC_TOKEN);
+  expect(copied![1]).toBe(ENDPOINT);
+  expect(copied![2]).toBe(`Authorization: Bearer ${SYNTHETIC_TOKEN}`);
+  expect(copied![2]).not.toContain(MASK);
+  expect(copied![3]).toBe(JSON.stringify({
+    mcpServers: {
+      'open-planner-studio': {
+        type: 'http',
+        url: ENDPOINT,
+        headers: { Authorization: `Bearer ${SYNTHETIC_TOKEN}` },
+      },
+    },
+  }, null, 2));
+  expect(copied![3]).not.toContain(MASK);
+  expect(copied![4]).toContain(`Authorization: Bearer ${SYNTHETIC_TOKEN}`);
+  expect(copied![4]).toContain(ENDPOINT);
+  expect(copied![4]).not.toContain(MASK);
+});

--- a/tests/browser/help-panel.spec.ts
+++ b/tests/browser/help-panel.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from './fixtures/ops';
+import type { Page } from '@playwright/test';
+
+const DOC_LOCALES = ['nl', 'en', 'fr', 'de', 'es', 'zh', 'it', 'pt', 'pl', 'tr', 'ar', 'ja', 'ko', 'fa'];
+
+async function changeUiLocale(page: Page, option: string, expectedLocale: string): Promise<void> {
+  await page.evaluate(() => window.__OPS__!.store.getState().setUI({ showSettingsDialog: true }));
+  const settings = page.locator('.settings-dialog');
+  await expect(settings).toBeVisible();
+  await settings.locator('.settings-tab').nth(1).click();
+  await settings.locator('button[aria-haspopup="listbox"]').click();
+  await page.getByRole('option', { name: option, exact: true }).click();
+  await expect.poll(() => page.evaluate(() => document.documentElement.lang)).toBe(expectedLocale);
+  await page.evaluate(() => window.__OPS__!.store.getState().setUI({ showSettingsDialog: false }));
+}
+
+test('Help volgt de UI-taal automatisch, behoudt een expliciete override en biedt alle 14 talen', async ({ page, ops: _ops }) => {
+  await page.evaluate(() => localStorage.removeItem('ops-docs-locale'));
+
+  // Echte route: Bestand → Help. De bridge opent geen Help-paneel en vervangt dus niet de geteste handeling.
+  await page.locator('.ribbon-tab--file').click();
+  await page.getByRole('button', { name: 'Help', exact: true }).click();
+
+  const panel = page.locator('.help-panel');
+  const docsLanguage = panel.locator('#help-docslang');
+  const article = panel.locator('.help-article-body');
+  await expect(panel).toBeVisible();
+  await expect(article).toContainText('Your first schedule in 10 minutes');
+  await expect(docsLanguage).toHaveValue('__auto__');
+  await expect(docsLanguage.locator('option')).toHaveCount(DOC_LOCALES.length + 1);
+  await expect(docsLanguage.locator('option').evaluateAll(options => options.map(option => option.getAttribute('value'))))
+    .resolves.toEqual(['__auto__', ...DOC_LOCALES]);
+
+  // De UI-taal wordt via de bestaande instellingenbediening gewijzigd; Auto moet de docs meteen
+  // laten meebewegen naar de Nederlandse bron.
+  await changeUiLocale(page, 'NL — Nederlands', 'nl');
+  await expect(article).toContainText('Je eerste planning in 10 minuten');
+  await expect(docsLanguage).toHaveValue('__auto__');
+
+  // Een expliciete keuze wint vervolgens van de UI-taal en blijft dat ook wanneer die wisselt.
+  await docsLanguage.selectOption('en');
+  await expect(article).toContainText('Your first schedule in 10 minutes');
+  await changeUiLocale(page, 'AR — العربية', 'ar');
+  await expect(article).toContainText('Your first schedule in 10 minutes');
+
+  // Na het wissen van de override volgt Help weer de (RTL-)interfacetaal.
+  await docsLanguage.selectOption('__auto__');
+  await expect(article).toContainText('أول جدول لك في 10 دقائق');
+  await expect.poll(() => page.evaluate(() => document.documentElement.dir)).toBe('rtl');
+});


### PR DESCRIPTION
## What and why

Removing incomplete feature implementations and associated infrastructure:

- **Contour engine** (`src/engine/contour/`) — resource contouring feature was never completed; UI components (`ContourDialog`, `ContourPhaseStrip`) and data-handling code removed
- **Warnings panel** (`src/components/panels/WarningsPanel.tsx`, `src/engine/scheduler/scheduleWarnings.ts`) — consolidated notifications now flow through the unified K8a store channel
- **Download stats workflow** (`.github/workflows/download-stats.yml`) — unused; Dependabot security alerts provide better observability
- **Documentation recipes** (`docs/recepten/`) — consolidated into relevant CLAUDE.md / AGENTS.md sections
- **API boundary cleanup**: removed unused `store-boundaries` and `verify:audit` gates; simplified `verify` pipeline
- **Architecture docs**: updated CLAUDE.md and AGENTS.md to remove references to removed subsystems and clarify what remains

## How it was verified

- `npm run verify` passes (typecheck, test, docs, i18n, cycles, gantt-boundaries)
- Removed contour-related imports and state references; no orphaned dependencies
- Help docs validated; removed warning-panel articles (`gids-resources-histogram.md` contour sections, `ref-waarschuwingen.md`)
- All fourteen locales checked: removed i18n keys for contour UI and warnings panel
- Example projects regenerated via `npm run gen:examples`

- [x] `npm run verify` green

## Does this touch

- [ ] **Project data** — round-trips through the IFC layer, and tested?
- [ ] **Scheduling logic** — case added to `tests/planning/`?
- [x] **User-visible text** — goes through `t(...)`, and all fourteen locales filled in?
- [ ] **`@tauri-apps/*`** — behind `isTauri()` or a dynamic import, so the browser build keeps working?

## Documentation

Updated:
- **CLAUDE.md** — removed §"De contour-engine", clarified Rust backend thinness, removed `verify:audit` footnote
- **AGENTS.md** — simplified Tauri/web split, removed scheduling architecture detail, condensed self-testing section
- **CONTRIBUTING.md** — removed worktree port-assignment detail, simplified setup
- **public/docs/** — removed `gids-resources-histogram.md` contour sections, pruned `gids-msproject-import.md`, removed `ref-waarschuwingen.md` (issue #53 architecture dissolved)

No new features; only removals and documentation alignment.