### PR TITLE
Path tracing: trace-tint niet meer overschilderd door voortgang; rastermarkering in Gantt-kleuren; resourcekleur in compact paneel

### DIFF
--- a/public/docs/en/gids-resourcebibliotheken.md
+++ b/public/docs/en/gids-resourcebibliotheken.md
@@ -54,7 +54,9 @@ levels: **View → Bar colors → By category → Resource** colors the whole ba
 each party's assignment, with the critical path as a red outline), and the separate **Resource
 accent** toggle (View → Baselines & progress) adds a thin stripe in the resource color under the
 bar. That accent is independent of the selected bar coloring, so it can also be combined with Task
-type, Discipline or automatic per-task colors.
+type, Discipline or automatic per-task colors. The compact Resources panel in the right rail shows
+the same color swatch in front of every resource, so you can tie an accent stripe to its resource at
+a glance.
 
 ## What follows the library — and what doesn't
 

--- a/public/docs/nl/gids-resourcebibliotheken.md
+++ b/public/docs/nl/gids-resourcebibliotheken.md
@@ -54,7 +54,9 @@ gradaties: **Beeld → Balkkleuren → Op categorie → Resource** kleurt de hel
 partijen gesegmenteerd naar verhouding van hun inzet, met het kritieke pad als rode rand), en de
 aparte toggle **Resource-accent** (Beeld → Baselines & voortgang) zet een dun streepje in de
 resourcekleur onder de balk. Dat accent staat los van de gekozen balkkleuring en kan dus ook samen
-met Taaktype, Discipline of de automatische taakkleuren aanstaan.
+met Taaktype, Discipline of de automatische taakkleuren aanstaan. Het compacte Resources-paneel in
+de rechterrail toont vóór elke resource hetzelfde kleurvlakje, zodat je een accentstreepje direct aan
+een resource kunt koppelen.
 
 ## Wat volgt de bibliotheek mee — en wat niet
 

--- a/src/components/panels/ResourcePanelCompact.tsx
+++ b/src/components/panels/ResourcePanelCompact.tsx
@@ -2,6 +2,8 @@ import { useAppStore } from '@/state/appStore';
 import { useTranslation } from 'react-i18next';
 import { UnitsInput } from '@/components/common/UnitsInput';
 import { scopeTaskResources } from '@/utils/taskResourceScope';
+import { ensureThemeVisible, resourceDisplayColor } from '@/engine/renderer/resourcePalette';
+import { useResolvedUITheme } from '@/hooks/useResolvedUITheme';
 
 /**
  * Fase 2.10 (item 6, architect-besluit 6): compacte resource-lijst voor de gedockte rechter-rail
@@ -9,7 +11,9 @@ import { scopeTaskResources } from '@/utils/taskResourceScope';
  * kolommenset t.o.v. de volledige `ResourcePanel`: alleen naam (readonly hier — hernoemen blijft
  * een taak voor het volledige paneel), max. eenheden (bewerkbaar, zelfde `updateResource`-actie)
  * en een simpele belasting-badge afgeleid uit `resourceLoadResult.overallocatedDays` (dezelfde bron
- * als het histogram) — géén tarief/kalender/eenheid/ouder-bewerking hier.
+ * als het histogram) — géén tarief/kalender/eenheid/ouder-bewerking hier. Issue #115: vóór de naam
+ * staat wél het kleurvlakje in de resourcekleur — dezelfde `resourceDisplayColor` (+ donker-thema-
+ * verlichting) als het resource-accent onder de Gantt-balk, zodat je dat accent hier kunt aflezen.
  */
 export function ResourcePanelCompact() {
   const { t } = useTranslation('common');
@@ -18,6 +22,7 @@ export function ResourcePanelCompact() {
   const selectedTaskIds = useAppStore(s => s.selectedTaskIds);
   const resourceLoadResult = useAppStore(s => s.resourceLoadResult);
   const updateResource = useAppStore(s => s.updateResource);
+  const darkTheme = useResolvedUITheme() === 'dark';
   const { resources } = scopeTaskResources(allResources, assignments, selectedTaskIds);
 
   if (resources.length === 0) {
@@ -35,6 +40,12 @@ export function ResourcePanelCompact() {
             key={r.id}
             className="flex items-center gap-1.5 px-1.5 py-1 rounded-[6px] hover:bg-surface-hover"
           >
+            <span
+              title={t('resource.color')}
+              className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+              style={{ background: ensureThemeVisible(resourceDisplayColor(r), darkTheme) }}
+              data-ops-resource-color={r.id}
+            />
             <span className="flex-1 truncate" title={r.name || r.id}>{r.name || r.id}</span>
             <UnitsInput
               value={r.maxUnits}

--- a/src/engine/renderer/GanttRenderer.ts
+++ b/src/engine/renderer/GanttRenderer.ts
@@ -1078,7 +1078,10 @@ export class GanttRenderer {
     const color = overrideColor ?? modeColor ?? this.barColor(task);
     // Voortgangsvulling: in de modi ligt er geen bijpassende "licht"-variant van een willekeurige
     // moduskleur — dan de vaste semi-transparante donkere laag (zelfde keuze als de printlaag).
-    const progressColor = selection.mode !== 'critical'
+    // Issue #114: óók bij een trace-tint (`overrideColor`). De blauwe/rode "licht"-variant hoort bij
+    // de standaardbalkkleur; op een goud/paarse voorganger-/opvolgerbalk verving hij die kleur juist —
+    // een voltooide taak was dan van een gedimde niet te onderscheiden en de trace leek niet te werken.
+    const progressColor = selection.mode !== 'critical' || overrideColor
       ? 'rgba(0, 0, 0, 0.25)'
       : task.time.isCritical ? this.colors.criticalLight : this.colors.normalLight;
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -189,12 +189,12 @@
 
 .task-grid-data-row.task-grid-trace-predecessor,
 .task-grid-data-row.task-grid-trace-predecessor-driving {
-  border-inline-start: 3px solid var(--trace-predecessor, #7c3aed);
+  border-inline-start: 3px solid var(--trace-predecessor, #F59E0B);
 }
 
 .task-grid-data-row.task-grid-trace-successor,
 .task-grid-data-row.task-grid-trace-successor-driving {
-  border-inline-start: 3px dashed var(--trace-successor, #0284c7);
+  border-inline-start: 3px dashed var(--trace-successor, #A78BFA);
 }
 
 .task-grid-data-row.task-grid-trace-predecessor-driving,
@@ -1149,6 +1149,12 @@ button.task-grid-relation-reference {
 :root {
   /* Brand — primary */
   --deep-forge:      #36363E;
+
+  /* Path tracing (issue #114): de rijmarkering in het taakraster gebruikt dezelfde tinten als de
+     Gantt-balken — GANTT_TRACE_COLORS in src/engine/renderer/themePalette.ts is de bron;
+     tests/planning/check-dependency-presentation.ts bewaakt dat beide gelijk blijven. */
+  --trace-predecessor: #F59E0B;
+  --trace-successor:   #A78BFA;
 
   /* Brand — secondary */
   --signal-orange:   #EA580C;

--- a/tests/browser/resource-compact-color.spec.ts
+++ b/tests/browser/resource-compact-color.spec.ts
@@ -1,0 +1,23 @@
+// Issue #115 (manuvarkey): het compacte Resources-paneel in de rechterrail toont per resource haar
+// kleur — dezelfde bron (`resourceDisplayColor`) als het resource-accent onder de Gantt-balk, zodat de
+// gebruiker het accent aan een resource kan koppelen.
+import { expect, test } from './fixtures/ops';
+
+test('compact resource panel: kleurvlakje per resource volgt de resourcekleur', async ({ page, ops: _ops }) => {
+  const ids = await page.evaluate(() => {
+    const s = window.__OPS__!.store.getState();
+    const withColor = s.addResource({ name: 'Metselaar', type: 'LABOR', description: '', maxUnits: 1, color: '#FBBF24' });
+    const noColor = s.addResource({ name: 'Kraan', type: 'EQUIPMENT', description: '', maxUnits: 1 });
+    s.setUI({ showResourcePanel: true, resourcePanelDocked: true, rightPanelCollapsed: false });
+    return { withColor, noColor };
+  });
+  const explicit = page.locator(`[data-ops-resource-color="${ids.withColor}"]`);
+  await expect(explicit).toBeVisible();
+  // Amber-400 ligt boven de donker-thema-verlichtingsdrempel van `ensureThemeVisible`, dus de
+  // verwachting is in licht én donker thema dezelfde hex (donkere tinten worden op donker verlicht).
+  await expect(explicit).toHaveCSS('background-color', 'rgb(251, 191, 36)');
+  // Zonder eigen kleur: de deterministische paletkleur, nooit leeg/transparant.
+  const auto = page.locator(`[data-ops-resource-color="${ids.noColor}"]`);
+  await expect(auto).toBeVisible();
+  await expect(auto).not.toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+});

--- a/tests/planning/check-dependency-presentation.ts
+++ b/tests/planning/check-dependency-presentation.ts
@@ -64,6 +64,36 @@ expectSource(
   component,
   /--dependency-role-color['"]?:\s*GANTT_TRACE_COLORS\[role\]/,
 );
+// Issue #114: de rijmarkering in het taakraster (border-inline-start) leest `--trace-predecessor`/
+// `--trace-successor`; die CSS-variabelen moeten letterlijk dezelfde hex dragen als het Gantt-palet,
+// anders staan er twee kleurtalen naast elkaar (raster paars/blauw, balken goud/paars — het
+// gerapporteerde beeld).
+function cssVar(name: string): string | null {
+  const m = new RegExp(`--${name}:\\s*(#[0-9A-Fa-f]{6})\\s*;`).exec(css);
+  return m ? m[1].toUpperCase() : null;
+}
+function paletteHex(key: string): string | null {
+  const m = new RegExp(`GANTT_TRACE_COLORS\\s*=\\s*\\{[\\s\\S]*?\\b${key}:\\s*'(#[0-9A-Fa-f]{6})'`).exec(palette);
+  return m ? m[1].toUpperCase() : null;
+}
+checks += 2;
+if (cssVar('trace-predecessor') === null || cssVar('trace-predecessor') !== paletteHex('predecessor')) {
+  diffs.push(`--trace-predecessor (${cssVar('trace-predecessor')}) ≠ GANTT_TRACE_COLORS.predecessor (${paletteHex('predecessor')})`);
+}
+if (cssVar('trace-successor') === null || cssVar('trace-successor') !== paletteHex('successor')) {
+  diffs.push(`--trace-successor (${cssVar('trace-successor')}) ≠ GANTT_TRACE_COLORS.successor (${paletteHex('successor')})`);
+}
+expectSource(
+  'rastermarkering voorganger leest de gedeelde trace-variabele',
+  css,
+  /\.task-grid-trace-predecessor-driving \{\s*border-inline-start: 3px solid var\(--trace-predecessor, #F59E0B\);/,
+);
+expectSource(
+  'rastermarkering opvolger leest de gedeelde trace-variabele',
+  css,
+  /\.task-grid-trace-successor-driving \{\s*border-inline-start: 3px dashed var\(--trace-successor, #A78BFA\);/,
+);
+
 expectSource(
   'het Gantt-palet exporteert de semantische voorganger-/opvolgerkleuren',
   palette,

--- a/tests/planning/check-gantt-trace-progress.ts
+++ b/tests/planning/check-gantt-trace-progress.ts
@@ -1,0 +1,122 @@
+// Issue #114 (manuvarkey): "Predecessors/Successors colour not being set". De trace-tint (goud voor
+// voorgangers, paars voor opvolgers) werd wél als balkkleur gezet, maar in de standaard kleurmodus
+// tekende de voortgangsvulling daarna `normalLight`-blauw (of `criticalLight`-rood) over de balk —
+// bij een voltooide taak dus de héle balk. Precies de voorbeeldprojecten (status-datum in het verleden,
+// vroege taken 100 %) toonden zo geen enkele trace-kleur; alleen het dimmen van de rest was zichtbaar.
+//
+// Deze batterij draait de ECHTE GanttRenderer met een opnemende 2D-context over één voltooide
+// voorganger + focus-taak, met de trace aan, en eist dat GEEN vulling in de rij van de voorganger de
+// blauwe/rode "licht"-variant gebruikt: de trace-tint zelf, plus de neutrale donkere voortgangslaag.
+// Zonder trace blijft de bestaande blauwe voortgangsvulling byte-identiek (regressie-anker).
+//
+// Draait via run.sh. Exit 0 = alles groen.
+
+const g = globalThis as unknown as Record<string, unknown>;
+g.document = { documentElement: {} };
+g.getComputedStyle = () => ({ getPropertyValue: () => '' });
+
+import { useAppStore } from '@/state/appStore';
+import { GanttRenderer } from '@/engine/renderer/GanttRenderer';
+import { GANTT_TRACE_COLORS } from '@/engine/renderer/themePalette';
+import { buildTrace } from '@/engine/taskGrid/trace';
+import type { ViewRow } from '@/engine/view/visibleRows';
+
+const S = () => useAppStore.getState();
+
+let checks = 0;
+const diffs: string[] = [];
+function ok(label: string, cond: boolean): void {
+  checks++;
+  if (!cond) diffs.push(label);
+}
+
+// Opnemende context: elke `fill()` legt de op dat moment actieve fillStyle + laatste roundRect vast.
+interface Fill { x: number; y: number; w: number; h: number; style: string }
+function makeCtx(): { ctx: CanvasRenderingContext2D; fills: Fill[] } {
+  const fills: Fill[] = [];
+  const noop = () => {};
+  let last: { x: number; y: number; w: number; h: number } | null = null;
+  const ctx = {
+    fillStyle: '', strokeStyle: '', lineWidth: 1, font: '', textAlign: '', textBaseline: '',
+    globalAlpha: 1, lineCap: '', lineJoin: '', shadowBlur: 0, shadowColor: '',
+    fillRect: noop, strokeRect: noop, clearRect: noop, beginPath: () => { last = null; }, closePath: noop,
+    moveTo: noop, lineTo: noop, arc: noop, arcTo: noop, ellipse: noop, rect: noop,
+    roundRect: (x: number, y: number, w: number, h: number) => { last = { x, y, w, h }; },
+    fill: () => { if (last) fills.push({ ...last, style: String(ctx.fillStyle) }); },
+    stroke: noop, save: noop, restore: noop, clip: noop,
+    translate: noop, scale: noop, rotate: noop,
+    setLineDash: noop, getLineDash: () => [], fillText: noop, strokeText: noop,
+    measureText: (t: string) => ({ width: String(t).length * 6 }),
+    createLinearGradient: () => ({ addColorStop: noop }),
+    createPattern: () => null,
+    quadraticCurveTo: noop, bezierCurveTo: noop, drawImage: noop,
+  };
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, fills };
+}
+
+// ── Scenario: voltooide voorganger → focus-taak (beide 100 %) ────────────────
+S().newProject();
+S().addTask({ name: 'Voorganger' });
+S().addTask({ name: 'Focus' });
+const [predId, focusId] = S().tasks.map(t => t.id);
+S().addSequence({ predecessorId: predId, successorId: focusId, type: 'FINISH_START', lagDays: 0 });
+S().updateTask(predId, { time: { ...S().tasks[0].time, completion: 1 } });
+S().updateTask(focusId, { time: { ...S().tasks[1].time, completion: 1 } });
+S().runCPM();
+
+const st = S();
+const rows: ViewRow[] = st.tasks.map(task => ({ kind: 'task', rowKey: task.id, task, depth: 0, dimmed: false }));
+const ROWH = 28, HDRH = 60;
+const inRow = (f: Fill, i: number) => f.y >= HDRH + i * ROWH && f.y + f.h <= HDRH + (i + 1) * ROWH;
+const LIGHT = ['#1D4ED8', '#991B1B'].map(c => c.toLowerCase());
+
+function render(traceMode: 'off' | 'predecessors' | 'successors'): Fill[] {
+  const { ctx, fills } = makeCtx();
+  const focus = traceMode === 'successors' ? predId : focusId;
+  const renderer = new GanttRenderer(ctx, {
+    rows,
+    sequences: st.sequences,
+    calendar: st.calendar,
+    view: { ...st.view, scrollX: 0, scrollY: 0 },
+    selectedTaskIds: [focus],
+    trace: buildTrace(traceMode, [focus], st.sequences, st.cpmResult),
+    canvasWidth: 1200,
+    canvasHeight: 400,
+    rowHeight: ROWH,
+    headerHeight: HDRH,
+  });
+  renderer.render();
+  return fills;
+}
+
+// Regressie-anker: zonder trace tekent een voltooide taak nog steeds de blauwe voortgangsvulling.
+const off = render('off').filter(f => inRow(f, 0));
+ok('zonder trace: voltooide balk mist de standaard voortgangsvulling', off.some(f => LIGHT.includes(f.style.toLowerCase())));
+
+// Predecessors: rij 0 (de voorganger) krijgt de goudtint en géén blauwe/rode vulling eroverheen.
+const pred = render('predecessors').filter(f => inRow(f, 0));
+// FS-voorganger van de focus is per definitie driving ⇒ de donkere goudtint; de lichte telt ook.
+const GOLD = [GANTT_TRACE_COLORS.predecessor, GANTT_TRACE_COLORS.predecessorDriving].map(c => c.toLowerCase());
+ok('predecessors: voorgangerbalk tekent niet in de trace-goudtint', pred.some(f => GOLD.includes(f.style.toLowerCase())));
+ok(
+  `predecessors: voltooide voorganger krijgt de blauwe/rode voortgangsvulling over de trace-tint (${pred.map(f => f.style).join(', ')})`,
+  !pred.some(f => LIGHT.includes(f.style.toLowerCase())),
+);
+ok('predecessors: voortgang blijft zichtbaar als neutrale donkere laag', pred.some(f => f.style.startsWith('rgba(0, 0, 0')));
+
+// Successors (focus = voorganger): rij 1 (de opvolger) idem in paars.
+const succ = render('successors').filter(f => inRow(f, 1));
+const PURPLE = [GANTT_TRACE_COLORS.successor, GANTT_TRACE_COLORS.successorDriving].map(c => c.toLowerCase());
+ok('successors: opvolgerbalk tekent niet in de trace-paarstint', succ.some(f => PURPLE.includes(f.style.toLowerCase())));
+ok(
+  `successors: voltooide opvolger krijgt de blauwe/rode voortgangsvulling over de trace-tint (${succ.map(f => f.style).join(', ')})`,
+  !succ.some(f => LIGHT.includes(f.style.toLowerCase())),
+);
+
+if (diffs.length === 0) {
+  console.log(`check-gantt-trace-progress: ${checks} checks, alles groen`);
+} else {
+  for (const d of diffs) console.log(`XX ${d}`);
+  console.log(`check-gantt-trace-progress: ${diffs.length}/${checks} checks rood`);
+  process.exit(1);
+}

--- a/tests/planning/run.sh
+++ b/tests/planning/run.sh
@@ -579,6 +579,11 @@ if [ "$RUN_HOLIDAYS" -eq 1 ]; then
   RDCHECK="$DIR/.renderer-dateless.mjs"
   if bundle_check "$DIR/check-renderer-dateless.ts" "$RDCHECK"; then node "$RDCHECK" || STATUS=1; fi
 
+  # Issue #114: de trace-tint (voorganger goud / opvolger paars) mag niet door de blauwe/rode
+  # voortgangsvulling worden overschilderd — een voltooide voorganger leek anders niet gemarkeerd.
+  TRACEPROGCHECK="$DIR/.gantt-trace-progress.mjs"
+  if bundle_check "$DIR/check-gantt-trace-progress.ts" "$TRACEPROGCHECK"; then node "$TRACEPROGCHECK" || STATUS=1; fi
+
   # Dev-only Gantt-testdriver: reverse locator gebruikt exact de renderer-eigen balkgeometrie en
   # behoudt het bestaande hit-testbeleid voor datumloze taken, mijlpalen en verzameltaken.
   GTDCHECK="$DIR/.gantt-test-driver.mjs"


### PR DESCRIPTION
### What and why

Fixes #114, fixes #115 (beide van @manuvarkey).

**#114 — Predecessors/Successors colour not being set.** Gereproduceerd op het voorbeeld *6 New Terraced Houses*: de voorgangers/opvolgers kregen wél de trace-tint (goud/paars) als balkkleur, maar in de standaard kleurmodus tekende de **voortgangsvulling** daarna `normalLight`-blauw (of `criticalLight`-rood) eroverheen — bij een voltooide taak dus de héle balk. De voorbeeldprojecten (statusdatum in het verleden, vroege taken 100 %) toonden zo geen enkele trace-kleur; alleen het dimmen van de rest was zichtbaar. Bij een `overrideColor` gebruikt de vulling nu de neutrale donkere laag (`rgba(0,0,0,.25)`), zoals in de andere kleurmodi al gebeurde. Gemeten na de fix: voorgangerbalk `rgb(183,118,8)` (goud + voortgangslaag), opvolger `rgb(125,104,187)` (paars + laag).

De **"gekleurde gebroken balkjes" links van de WBS-kolom** (Manu's tweede comment) zijn de trace-rijmarkering van het taakraster (`border-inline-start`, gestippeld voor opvolgers als niet-kleurgebonden onderscheid). Die las `--trace-predecessor`/`--trace-successor`, maar niemand definieerde die variabelen, dus vielen ze terug op paars/blauw — een andere kleurtaal dan de goud/paarse balken. De variabelen staan nu op `:root` met exact de `GANTT_TRACE_COLORS`-hex; `check-dependency-presentation` bewaakt dat CSS en palet gelijk blijven.

**#115 — Resource accent colour missing in Resources side bar.** Het compacte Resources-paneel in de rechterrail toont nu vóór elke resource haar kleurvlakje — dezelfde `resourceDisplayColor` (+ donker-thema-verlichting `ensureThemeVisible`) als het resource-accent onder de Gantt-balk, zodat het accent aan een resource te koppelen is.

### How it was verified

- [x] `npm run verify` green — op typecheck, lint, planning (incl. de tijdzone-matrix), library, mcp, dev-server en alle verify:*-poorten. In de browsersuite 120/122 groen; de 2 rode zijn `just-updated-dialog.spec.ts` op `net::ERR_CERT_AUTHORITY_INVALID` — de TLS-onderscheppende proxy van de sandbox waarin dit gebouwd is blokkeert de GitHub-Releases-fetch van die spec. Mijn diff raakt geen netwerkcode; CI draait die spec zonder proxy.
- Nieuw: `tests/planning/check-gantt-trace-progress.ts` (echte `GanttRenderer` met opnemende 2D-context: géén blauwe/rode vulling over de trace-tint, wél de neutrale voortgangslaag; zonder trace blijft de blauwe vulling als regressie-anker) en `tests/browser/resource-compact-color.spec.ts`.
- Met de hand (Playwright-script tegen de dev-build): voorbeeld geladen, taak 3.1 geselecteerd, Predecessors/Successors aan → balkpixels en rasterrandkleuren gemeten vóór (blauw / paars-blauw) en ná (goud / paars, consistent raster).

### Does this touch

- [ ] **Project data** — n.v.t., puur weergave
- [ ] **Scheduling logic** — n.v.t.
- [x] **User-visible text** — alleen de bestaande sleutel `resource.color` (alle 14 locales al aanwezig)
- [ ] **`@tauri-apps/*`** — n.v.t.

### Documentation

In-app gids `gids-resourcebibliotheken.md` (nl+en): het kleurvlakje in het compacte paneel is toegevoegd bij de uitleg van het resource-accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgsvS54koCTELACgr7Put7

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgsvS54koCTELACgr7Put7)_